### PR TITLE
feat(#1): API 클라이언트 & 인증 인프라 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "signsafe-web",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.95.2",
+        "framer-motion": "^12.38.0",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-pdf": "^10.4.1",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -1022,6 +1025,256 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+      "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-x64": "0.1.97",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+      "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+      "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+      "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+      "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+      "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+      "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+      "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+      "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+      "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1512,6 +1765,32 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
+      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2606,6 +2885,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2782,6 +3070,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3622,6 +3919,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4440,7 +4764,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4851,7 +5174,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4880,6 +5202,24 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
+      "integrity": "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
+    "node_modules/make-event-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+      "integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4888,6 +5228,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-refs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-2.0.0.tgz",
+      "integrity": "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge2": {
@@ -4936,6 +5293,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5323,6 +5695,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5461,6 +5845,35 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-pdf": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
+      "integrity": "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^2.0.0",
+        "make-event-props": "^2.0.0",
+        "merge-refs": "^2.0.0",
+        "pdfjs-dist": "5.4.296",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -6095,6 +6508,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6430,6 +6849,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.95.2",
+    "framer-motion": "^12.38.0",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-pdf": "^10.4.1",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,41 +1,351 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+import type {
+  LoginResponse,
+  SignupResponse,
+  User,
+  Contract,
+  ContractListResponse,
+  UploadContractResponse,
+  IngestionJob,
+  Clause,
+  ClauseListResponse,
+  SnippetsResponse,
+  RiskAnalysisResponse,
+  CreateAnalysisResponse,
+  EvidenceSet,
+  RetrieveEvidenceResponse,
+  RiskOverride,
+  AuditEvent,
+} from "@/types";
 
-function getToken(): string | null {
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+// ─────────────────────────────────────────────
+// Token management (in-memory, accessed lazily)
+// ─────────────────────────────────────────────
+
+function getAccessToken(): string | null {
   if (typeof window === "undefined") return null;
-  // Token is managed by the auth store; import lazily to avoid circular deps.
+  // Lazy import to avoid circular dependency at module initialisation.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { useAuthStore } = require("@/lib/auth");
-  return useAuthStore.getState().token;
+  return useAuthStore.getState().accessToken as string | null;
 }
+
+function setAccessToken(token: string): void {
+  if (typeof window === "undefined") return;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useAuthStore } = require("@/lib/auth");
+  useAuthStore.getState().setAccessToken(token);
+}
+
+function clearAuth(): void {
+  if (typeof window === "undefined") return;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useAuthStore } = require("@/lib/auth");
+  useAuthStore.getState().clearAuth();
+}
+
+function redirectToLogin(): void {
+  if (typeof window !== "undefined") {
+    window.location.replace("/login");
+  }
+}
+
+// ─────────────────────────────────────────────
+// Refresh token logic (concurrent-safe via promise reuse)
+// ─────────────────────────────────────────────
+
+let refreshPromise: Promise<boolean> | null = null;
+
+async function refreshAccessToken(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    try {
+      const res = await fetch(`${API_URL}/auth/refresh`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) return false;
+      const data = (await res.json()) as LoginResponse;
+      setAccessToken(data.accessToken);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
+// ─────────────────────────────────────────────
+// Core request function
+// ─────────────────────────────────────────────
 
 async function request<T>(
   path: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  isRetry = false
 ): Promise<T> {
-  const token = getToken();
+  const token = getAccessToken();
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...(options.headers ?? {}),
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string> | undefined),
   };
 
-  const res = await fetch(`${API_URL}${path}`, { ...options, headers });
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  // Only set Content-Type for JSON bodies; multipart/form-data sets its own boundary.
+  if (
+    !(options.body instanceof FormData) &&
+    !headers["Content-Type"]
+  ) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const res = await fetch(`${API_URL}${path}`, {
+    ...options,
+    headers,
+    credentials: "include",
+  });
+
+  if (res.status === 401 && !isRetry) {
+    const refreshed = await refreshAccessToken();
+    if (!refreshed) {
+      clearAuth();
+      redirectToLogin();
+      // Return a never-resolving promise so callers don't see partial data.
+      return new Promise(() => {});
+    }
+    return request<T>(path, options, true);
+  }
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`API error ${res.status}: ${body}`);
+    throw new Error(`API ${res.status}: ${body}`);
   }
 
   if (res.status === 204) return undefined as unknown as T;
+
   return res.json() as Promise<T>;
 }
 
+// ─────────────────────────────────────────────
+// Auth endpoints
+// ─────────────────────────────────────────────
+
+async function login(email: string, password: string): Promise<LoginResponse> {
+  return request<LoginResponse>("/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+async function signup(
+  email: string,
+  password: string,
+  fullName: string
+): Promise<SignupResponse> {
+  return request<SignupResponse>("/auth/signup", {
+    method: "POST",
+    body: JSON.stringify({ email, password, fullName }),
+  });
+}
+
+async function verifyEmail(token: string): Promise<{ message: string }> {
+  return request<{ message: string }>("/auth/verify-email", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  });
+}
+
+async function logout(): Promise<{ message: string }> {
+  return request<{ message: string }>("/auth/logout", { method: "POST" });
+}
+
+async function forgotPassword(
+  email: string
+): Promise<{ message: string }> {
+  return request<{ message: string }>("/auth/password/forgot", {
+    method: "POST",
+    body: JSON.stringify({ email }),
+  });
+}
+
+async function resetPassword(
+  token: string,
+  newPassword: string
+): Promise<{ message: string }> {
+  return request<{ message: string }>("/auth/password/reset", {
+    method: "POST",
+    body: JSON.stringify({ token, newPassword }),
+  });
+}
+
+async function getMe(): Promise<User> {
+  return request<User>("/users/me");
+}
+
+// ─────────────────────────────────────────────
+// Contract endpoints
+// ─────────────────────────────────────────────
+
+async function listContracts(
+  organizationId: string,
+  page = 1,
+  pageSize = 20
+): Promise<ContractListResponse> {
+  return request<ContractListResponse>(
+    `/contracts?organizationId=${organizationId}&page=${page}&pageSize=${pageSize}`
+  );
+}
+
+async function uploadContract(
+  formData: FormData
+): Promise<UploadContractResponse> {
+  return request<UploadContractResponse>("/contracts", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+async function getIngestionJob(jobId: string): Promise<IngestionJob> {
+  return request<IngestionJob>(`/ingestion-jobs/${jobId}`);
+}
+
+async function listClauses(contractId: string): Promise<ClauseListResponse> {
+  return request<ClauseListResponse>(`/contracts/${contractId}/clauses`);
+}
+
+async function getSnippets(
+  contractId: string,
+  page: number,
+  startOffset: number,
+  endOffset: number
+): Promise<SnippetsResponse> {
+  return request<SnippetsResponse>(
+    `/contracts/${contractId}/snippets?page=${page}&startOffset=${startOffset}&endOffset=${endOffset}`
+  );
+}
+
+// ─────────────────────────────────────────────
+// Analysis endpoints
+// ─────────────────────────────────────────────
+
+async function createAnalysis(
+  contractId: string
+): Promise<CreateAnalysisResponse> {
+  return request<CreateAnalysisResponse>(
+    `/contracts/${contractId}/risk-analyses`,
+    { method: "POST", body: JSON.stringify({}) }
+  );
+}
+
+async function getAnalysis(analysisId: string): Promise<RiskAnalysisResponse> {
+  return request<RiskAnalysisResponse>(`/risk-analyses/${analysisId}`);
+}
+
+async function createOverride(
+  analysisId: string,
+  clauseResultId: string,
+  newRiskLevel: string,
+  reason: string
+): Promise<RiskOverride> {
+  return request<RiskOverride>(
+    `/risk-analyses/${analysisId}/overrides`,
+    {
+      method: "POST",
+      body: JSON.stringify({ clauseResultId, newRiskLevel, reason }),
+    }
+  );
+}
+
+// ─────────────────────────────────────────────
+// Evidence endpoints
+// ─────────────────────────────────────────────
+
+async function getEvidenceSet(evidenceSetId: string): Promise<EvidenceSet> {
+  return request<EvidenceSet>(`/evidence-sets/${evidenceSetId}`);
+}
+
+async function retrieveEvidence(
+  evidenceSetId: string,
+  topK = 5,
+  filterParams = ""
+): Promise<RetrieveEvidenceResponse> {
+  return request<RetrieveEvidenceResponse>(
+    `/evidence-sets/${evidenceSetId}/retrieve`,
+    {
+      method: "POST",
+      body: JSON.stringify({ topK, filterParams }),
+    }
+  );
+}
+
+// ─────────────────────────────────────────────
+// Audit endpoints
+// ─────────────────────────────────────────────
+
+async function createAuditEvent(
+  action: string,
+  targetType?: string,
+  targetId?: string,
+  organizationId?: string,
+  context = ""
+): Promise<AuditEvent> {
+  return request<AuditEvent>("/audit-events", {
+    method: "POST",
+    body: JSON.stringify({
+      action,
+      targetType,
+      targetId,
+      organizationId,
+      context,
+    }),
+  });
+}
+
+// ─────────────────────────────────────────────
+// Exported API surface
+// ─────────────────────────────────────────────
+
 export const api = {
-  get: <T>(path: string) => request<T>(path),
-  post: <T>(path: string, body: unknown) =>
-    request<T>(path, { method: "POST", body: JSON.stringify(body) }),
-  put: <T>(path: string, body: unknown) =>
-    request<T>(path, { method: "PUT", body: JSON.stringify(body) }),
-  delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
+  // Auth
+  login,
+  signup,
+  verifyEmail,
+  logout,
+  forgotPassword,
+  resetPassword,
+  getMe,
+
+  // Contracts
+  listContracts,
+  uploadContract,
+  getIngestionJob,
+  listClauses,
+  getSnippets,
+
+  // Analysis
+  createAnalysis,
+  getAnalysis,
+  createOverride,
+
+  // Evidence
+  getEvidenceSet,
+  retrieveEvidence,
+
+  // Audit
+  createAuditEvent,
 };
+
+// Also expose the raw request helper for edge cases.
+export { request };
+
+// Re-export Clause type parsed from ClauseResult for convenience.
+export type { Clause };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,19 +1,23 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import type { User } from "@/types";
 
 interface AuthState {
-  token: string | null;
-  setToken: (token: string) => void;
-  clearToken: () => void;
+  accessToken: string | null;
+  user: User | null;
+  setAuth: (token: string, user: User) => void;
+  clearAuth: () => void;
+  setAccessToken: (token: string) => void;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      token: null,
-      setToken: (token) => set({ token }),
-      clearToken: () => set({ token: null }),
-    }),
-    { name: "signsafe-auth" }
-  )
-);
+/**
+ * Auth store.
+ * - accessToken is stored in memory only (never in localStorage/sessionStorage).
+ * - Refresh Token lives in httpOnly cookie managed by the API server.
+ */
+export const useAuthStore = create<AuthState>()((set) => ({
+  accessToken: null,
+  user: null,
+  setAuth: (token, user) => set({ accessToken: token, user }),
+  clearAuth: () => set({ accessToken: null, user: null }),
+  setAccessToken: (token) => set({ accessToken: token }),
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,35 +1,247 @@
+// ─────────────────────────────────────────────
+// Auth
+// ─────────────────────────────────────────────
 export interface User {
   id: string;
   email: string;
-  name: string;
+  fullName: string;
+  role: string;
+  emailVerified: boolean;
+  mfaEnabled: boolean;
   createdAt: string;
+  permissions: string[];
 }
 
-export type ContractStatus =
-  | "draft"
-  | "pending"
-  | "signed"
-  | "rejected"
-  | "expired";
+export interface LoginResponse {
+  accessToken: string;
+  expiresAt: string;
+}
 
-export interface Contract {
+export interface SignupResponse {
+  userId: string;
+  message: string;
+}
+
+// ─────────────────────────────────────────────
+// Organization
+// ─────────────────────────────────────────────
+export interface Organization {
   id: string;
-  title: string;
-  status: ContractStatus;
-  ownerId: string;
+  name: string;
+  plan: string;
+  features: string;
   createdAt: string;
   updatedAt: string;
 }
 
-export interface Signer {
+// ─────────────────────────────────────────────
+// Contract
+// ─────────────────────────────────────────────
+export type ContractStatus =
+  | "uploaded"
+  | "processing"
+  | "ready"
+  | "failed";
+
+export interface Contract {
   id: string;
-  contractId: string;
-  email: string;
-  name: string;
+  organizationId: string;
+  uploadedBy: string;
+  title: string;
+  status: ContractStatus;
+  filePath: string;
+  fileName: string;
+  fileSize: number;
+  fileMimeType: string;
+  parties: string;
+  tags: string;
+  language: string;
+  contractType: string | null;
   signedAt: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
 }
 
+export interface ContractListResponse {
+  contracts: Contract[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface UploadContractResponse {
+  contractId: string;
+  jobId: string;
+}
+
+// ─────────────────────────────────────────────
+// Ingestion Job
+// ─────────────────────────────────────────────
+export type IngestionJobStatus =
+  | "pending"
+  | "parsing"
+  | "chunking"
+  | "indexing"
+  | "completed"
+  | "failed";
+
+export interface IngestionJob {
+  id: string;
+  contractId: string;
+  status: IngestionJobStatus;
+  progress: number;
+  currentStep: string | null;
+  errorMessage: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ─────────────────────────────────────────────
+// Clause
+// ─────────────────────────────────────────────
+export interface Clause {
+  id: string;
+  contractId: string;
+  clauseIndex: number;
+  label: string | null;
+  content: string;
+  pageStart: number;
+  pageEnd: number;
+  anchorX: number | null;
+  anchorY: number | null;
+  anchorWidth: number | null;
+  anchorHeight: number | null;
+  startOffset: number;
+  endOffset: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ClauseListResponse {
+  clauses: Clause[];
+  total: number;
+}
+
+export interface SnippetsResponse {
+  snippets: Clause[];
+}
+
+// ─────────────────────────────────────────────
+// Risk Analysis
+// ─────────────────────────────────────────────
+export type RiskLevel = "HIGH" | "MEDIUM" | "LOW" | "none";
+export type AnalysisStatus = "pending" | "running" | "completed" | "failed";
+
+export interface RiskAnalysis {
+  id: string;
+  contractId: string;
+  requestedBy: string;
+  status: AnalysisStatus;
+  modelVersion: string | null;
+  errorMessage: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ClauseResult {
+  id: string;
+  analysisId: string;
+  clauseId: string;
+  riskLevel: RiskLevel;
+  issueType: string | null;
+  summary: string | null;
+  highlightX: number | null;
+  highlightY: number | null;
+  highlightWidth: number | null;
+  highlightHeight: number | null;
+  pageNumber: number | null;
+  overriddenRiskLevel: string | null;
+  overrideReason: string | null;
+  overriddenBy: string | null;
+  overriddenAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RiskAnalysisResponse {
+  analysis: RiskAnalysis;
+  clauseResults: ClauseResult[];
+}
+
+export interface CreateAnalysisResponse {
+  analysisId: string;
+  status: string;
+}
+
+// ─────────────────────────────────────────────
+// Evidence Set
+// ─────────────────────────────────────────────
+export interface Citation {
+  id: string;
+  type: "case" | "policy" | "guideline" | "clause";
+  title: string;
+  snippet: string;
+  whyRelevant: string;
+  source?: string;
+  score?: number;
+}
+
+export interface EvidenceSet {
+  id: string;
+  clauseResultId: string;
+  rationale: string;
+  citations: string; // JSON string of Citation[]
+  recommendedActions: string; // JSON string of string[]
+  topK: number;
+  filterParams: string;
+  retrievedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RetrieveEvidenceResponse {
+  evidenceSetId: string;
+  status: string;
+}
+
+// ─────────────────────────────────────────────
+// Risk Override
+// ─────────────────────────────────────────────
+export interface RiskOverride {
+  id: string;
+  clauseResultId: string;
+  originalRiskLevel: string;
+  newRiskLevel: string;
+  reason: string;
+  decidedBy: string;
+  createdAt: string;
+}
+
+// ─────────────────────────────────────────────
+// Audit
+// ─────────────────────────────────────────────
+export interface AuditEvent {
+  id: string;
+  actorId: string | null;
+  actorEmail: string | null;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  organizationId: string | null;
+  context: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+}
+
+// ─────────────────────────────────────────────
+// Common
+// ─────────────────────────────────────────────
 export interface ApiError {
-  code: string;
-  message: string;
+  error: string;
 }


### PR DESCRIPTION
## 변경사항
- src/types/index.ts: API 응답 타입 전체 정의
- src/lib/auth.ts: Zustand 스토어 (메모리 전용, persist 제거)
- src/lib/api.ts: 완전한 API 클라이언트 (자동 토큰 주입, 401 재시도, concurrent refresh 방지)
- 라이브러리 추가: @tanstack/react-query, react-pdf, framer-motion

## QA 결과
- tsc --noEmit: PASS

Closes #1