### PR TITLE
feat(#3): 인증 페이지 구현

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,21 @@
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold tracking-tight text-zinc-900">
+            SignSafe
+          </h1>
+          <p className="mt-1 text-sm text-zinc-500">
+            AI-powered contract risk analysis
+          </p>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,10 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { api } from "@/lib/api";
+import { useAuthStore } from "@/lib/auth";
+
+type FormState = {
+  status: "idle" | "loading" | "error";
+  error: string | null;
+};
+
 export default function LoginPage() {
+  const router = useRouter();
+  const setAuth = useAuthStore((s) => s.setAuth);
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [formState, setFormState] = useState<FormState>({
+    status: "idle",
+    error: null,
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormState({ status: "loading", error: null });
+
+    try {
+      const data = await api.login(email, password);
+      // Fetch user profile then redirect.
+      // We set the token first so getMe() can use it.
+      useAuthStore.getState().setAccessToken(data.accessToken);
+      const user = await api.getMe();
+      setAuth(data.accessToken, user);
+      router.replace("/contracts");
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Login failed. Please try again.";
+      setFormState({ status: "error", error: message });
+    }
+  }
+
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-sm space-y-6">
-        <h1 className="text-2xl font-bold text-center">Sign in to SignSafe</h1>
-        {/* TODO: implement login form */}
-      </div>
-    </main>
+    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200">
+      <h2 className="mb-6 text-center text-xl font-semibold text-zinc-900">
+        Sign in to your account
+      </h2>
+
+      {formState.error && (
+        <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700 ring-1 ring-red-200">
+          {formState.error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="email"
+            className="mb-1 block text-sm font-medium text-zinc-700"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            placeholder="you@example.com"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="mb-1 block text-sm font-medium text-zinc-700"
+          >
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            placeholder="••••••••"
+          />
+        </div>
+
+        <div className="flex items-center justify-end">
+          <Link
+            href="/forgot-password"
+            className="text-xs text-zinc-500 hover:text-zinc-700 hover:underline"
+          >
+            Forgot password?
+          </Link>
+        </div>
+
+        <button
+          type="submit"
+          disabled={formState.status === "loading"}
+          className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {formState.status === "loading" ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-zinc-500">
+        No account?{" "}
+        <Link
+          href="/signup"
+          className="font-medium text-zinc-900 hover:underline"
+        >
+          Create one
+        </Link>
+      </p>
+    </div>
   );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { api } from "@/lib/api";
+
+type FormState = {
+  status: "idle" | "loading" | "success" | "error";
+  error: string | null;
+};
+
+export default function SignupPage() {
+  const router = useRouter();
+
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [agreed, setAgreed] = useState(false);
+  const [formState, setFormState] = useState<FormState>({
+    status: "idle",
+    error: null,
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!agreed) {
+      setFormState({
+        status: "error",
+        error: "You must agree to the terms of service.",
+      });
+      return;
+    }
+
+    setFormState({ status: "loading", error: null });
+
+    try {
+      await api.signup(email, password, fullName);
+      setFormState({ status: "success", error: null });
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Signup failed. Please try again.";
+      setFormState({ status: "error", error: message });
+    }
+  }
+
+  if (formState.status === "success") {
+    return (
+      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 mx-auto">
+          <svg
+            className="h-6 w-6 text-green-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        </div>
+        <h2 className="text-lg font-semibold text-zinc-900">Check your inbox</h2>
+        <p className="text-sm text-zinc-500">
+          We&apos;ve sent a verification link to{" "}
+          <span className="font-medium text-zinc-900">{email}</span>. Click it
+          to activate your account.
+        </p>
+        <button
+          onClick={() => router.push("/login")}
+          className="mt-2 text-sm font-medium text-zinc-900 hover:underline"
+        >
+          Back to sign in
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200">
+      <h2 className="mb-6 text-center text-xl font-semibold text-zinc-900">
+        Create your account
+      </h2>
+
+      {formState.error && (
+        <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700 ring-1 ring-red-200">
+          {formState.error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="fullName"
+            className="mb-1 block text-sm font-medium text-zinc-700"
+          >
+            Full name
+          </label>
+          <input
+            id="fullName"
+            type="text"
+            autoComplete="name"
+            required
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            placeholder="Jane Doe"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="email"
+            className="mb-1 block text-sm font-medium text-zinc-700"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            placeholder="you@example.com"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="mb-1 block text-sm font-medium text-zinc-700"
+          >
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            placeholder="Min. 8 characters"
+          />
+        </div>
+
+        <label className="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={agreed}
+            onChange={(e) => setAgreed(e.target.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-500"
+          />
+          <span className="text-sm text-zinc-600">
+            I agree to the{" "}
+            <a href="/terms" className="font-medium text-zinc-900 hover:underline">
+              Terms of Service
+            </a>{" "}
+            and{" "}
+            <a href="/privacy" className="font-medium text-zinc-900 hover:underline">
+              Privacy Policy
+            </a>
+          </span>
+        </label>
+
+        <button
+          type="submit"
+          disabled={formState.status === "loading"}
+          className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {formState.status === "loading" ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-zinc-500">
+        Already have an account?{" "}
+        <Link href="/login" className="font-medium text-zinc-900 hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { api } from "@/lib/api";
+
+type PageState = "loading" | "success" | "error" | "missing";
+
+export default function VerifyEmailPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [state, setState] = useState<PageState>("loading");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (!token) {
+      setState("missing");
+      return;
+    }
+
+    api
+      .verifyEmail(token)
+      .then(() => {
+        setState("success");
+        setTimeout(() => router.replace("/login"), 2500);
+      })
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Verification failed.";
+        setErrorMsg(message);
+        setState("error");
+      });
+  }, [searchParams, router]);
+
+  if (state === "loading") {
+    return (
+      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center">
+        <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-900" />
+        <p className="mt-4 text-sm text-zinc-500">Verifying your email…</p>
+      </div>
+    );
+  }
+
+  if (state === "success") {
+    return (
+      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 mx-auto">
+          <svg
+            className="h-6 w-6 text-green-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        </div>
+        <h2 className="text-lg font-semibold text-zinc-900">Email verified!</h2>
+        <p className="text-sm text-zinc-500">
+          Redirecting you to sign in…
+        </p>
+      </div>
+    );
+  }
+
+  if (state === "missing") {
+    return (
+      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
+        <h2 className="text-lg font-semibold text-zinc-900">Missing token</h2>
+        <p className="text-sm text-zinc-500">
+          The verification link is invalid or expired. Check your inbox for the
+          latest verification email.
+        </p>
+        <Link href="/login" className="text-sm font-medium text-zinc-900 hover:underline">
+          Back to sign in
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 mx-auto">
+        <svg
+          className="h-6 w-6 text-red-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </div>
+      <h2 className="text-lg font-semibold text-zinc-900">Verification failed</h2>
+      {errorMsg && (
+        <p className="text-sm text-red-600">{errorMsg}</p>
+      )}
+      <Link href="/login" className="text-sm font-medium text-zinc-900 hover:underline">
+        Back to sign in
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경사항
- (auth)/layout.tsx: 인증 레이아웃
- login/page.tsx: 로그인 폼, 성공 시 user 정보 로드 후 /contracts 이동
- signup/page.tsx: 회원가입 폼 + 이메일 인증 안내 화면
- verify-email/page.tsx: ?token으로 POST /auth/verify-email 처리

## QA 결과
- tsc --noEmit: PASS

Closes #3