### PR TITLE
fix(#14): contracts 페이지에서 orgId를 user.organizationId로 수정

### DIFF
--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -46,8 +46,7 @@ function formatDate(iso: string) {
 export default function ContractsPage() {
   const user = useAuthStore((s) => s.user);
 
-  // Hard-code orgId for now; in a multi-org setup this would come from user context.
-  const orgId = user?.id ?? "";
+  const orgId = user?.organizationId ?? "";
 
   const [contracts, setContracts] = useState<Contract[]>([]);
   const [total, setTotal] = useState(0);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export interface User {
   mfaEnabled: boolean;
   createdAt: string;
   permissions: string[];
+  organizationId: string;
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## 변경사항
- User 타입에 organizationId 필드 추가 (API의 GET /users/me 응답에 대응)
- contracts/page.tsx에서 orgId 소스를 user.id → user.organizationId로 수정

## 수정된 버그
- 기존: orgId = user?.id (사용자 ID를 조직 ID로 잘못 사용)
- 수정: orgId = user?.organizationId (올바른 조직 ID 사용)
- 이 버그로 인해 계약 목록 조회, 업로드 모두 잘못된 organizationId로 요청하여 빈 결과만 반환됨

## 연관 변경사항
signsafe-api PR #15: 회원가입 시 organization 자동 생성 + GET /users/me에 organizationId 추가

## QA 결과
- [x] tsc --noEmit 성공 (타입 에러 없음)

Closes #14