### PR TITLE
feat(#18): 계약 상세 페이지에서 getContract API 사용

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -76,14 +76,12 @@ export default function ContractViewerPage({
     async function load() {
       setLoadState("loading");
       try {
-        const [contractsData, clausesData] = await Promise.all([
-          api.listContracts("").catch(() => ({ contracts: [] as Contract[], total: 0, page: 1, pageSize: 20 })),
+        const [contractData, clausesData] = await Promise.all([
+          api.getContract(contractId),
           api.listClauses(contractId),
         ]);
 
-        // listContracts needs an orgId; fall back to fetching by individual lookup.
-        // For now use the clauses to get contractId, and trust the router param.
-        void contractsData;
+        setContract(contractData);
         setClauses(clausesData.clauses ?? []);
         setLoadState("success");
       } catch {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -205,6 +205,10 @@ async function listContracts(
   );
 }
 
+async function getContract(contractId: string): Promise<Contract> {
+  return request<Contract>(`/contracts/${contractId}`);
+}
+
 async function uploadContract(
   formData: FormData
 ): Promise<UploadContractResponse> {
@@ -326,6 +330,7 @@ export const api = {
 
   // Contracts
   listContracts,
+  getContract,
   uploadContract,
   getIngestionJob,
   listClauses,


### PR DESCRIPTION
## 변경사항
- `api.ts`: `getContract(contractId)` 함수 추가 — `GET /contracts/:contractId`
- `contracts/[id]/page.tsx`: `api.listContracts("")` 임시 코드 제거, `api.getContract`로 교체
  - `setContract(contractData)` 호출로 계약 객체 실제 로드
  - 계약 title 표시, pdfUrl 계산 정상화

## QA 결과
- `tsc --noEmit` 통과

## 배경
signsafe-api #19 (GET /contracts/:contractId) 머지 대응.

Closes #18