### PR TITLE
fix(#22): AppLayout 새로고침 시 세션 복원 실패 및 관련 버그 수정

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -16,6 +16,11 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
     api
       .getMe()
+      .then((user) => {
+        // getMe() triggers a token refresh internally; grab the refreshed token.
+        const token = useAuthStore.getState().accessToken ?? "";
+        setAuth(token, user);
+      })
       .catch(() => {
         clearAuth();
         router.replace("/login");

--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -64,9 +64,7 @@ export default function IngestionProgress({
 
   const progress = job.progress ?? 0;
   const label =
-    (job.currentStep ? STEP_LABELS[job.currentStep] : null) ??
-    STEP_LABELS[job.status] ??
-    job.status;
+    STEP_LABELS[job.status] ?? job.status;
 
   const isFailed = job.status === "failed";
   const isComplete = job.status === "completed";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export interface LoginResponse {
 
 export interface SignupResponse {
   userId: string;
+  organizationId: string;
   message: string;
 }
 


### PR DESCRIPTION
## 변경사항
- **AppLayout 세션 복원 버그 수정 (Critical)**: 페이지 새로고침 후 `getMe()`가 성공해도 user와 accessToken을 Zustand store에 저장하지 않아 로그인 상태가 유지되지 않는 버그 수정. `.then((user) => setAuth(token, user))` 추가.
- **IngestionProgress 라벨 조회 버그 수정**: `STEP_LABELS`를 `job.currentStep`(한국어 문자열)으로 조회하던 코드를 `job.status`(영문 키)로 수정. 기존 코드는 항상 null을 반환해 fallback에만 의존했음.
- **SignupResponse 타입 수정**: API가 반환하는 `organizationId` 필드가 타입에 없어서 발생하는 불일치 해소.

## QA 결과
- [x] 새로고침 후 getMe() 성공 시 user가 store에 저장되어 헤더에 이름 표시됨
- [x] 새로고침 후 contracts 목록이 정상 로드됨 (user.organizationId 의존)
- [x] IngestionProgress 상태 라벨 (Queued, Parsing, etc.) 정상 표시됨
- [x] 타입스크립트 컴파일 오류 없음

Closes #22