### PR TITLE
fix(#24): IngestionProgress 폴링 타이머 조기 완료 시 인터벌 미취소 버그

### DIFF
--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import type { IngestionJob } from "@/types";
 
@@ -25,20 +25,27 @@ export default function IngestionProgress({
   onError,
 }: IngestionProgressProps) {
   const [job, setJob] = useState<IngestionJob | null>(null);
+  // Use a ref so the async poll callback always reads the latest timerId value.
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
-    let timerId: ReturnType<typeof setInterval> | null = null;
+    let stopped = false;
 
     async function poll() {
       try {
         const j = await api.getIngestionJob(jobId);
+        if (stopped) return; // component unmounted while request was in flight
         setJob(j);
-        if (j.status === "completed") {
-          if (timerId) clearInterval(timerId);
-          onComplete?.(j);
-        } else if (j.status === "failed") {
-          if (timerId) clearInterval(timerId);
-          onError?.(j);
+        if (j.status === "completed" || j.status === "failed") {
+          if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+          }
+          if (j.status === "completed") {
+            onComplete?.(j);
+          } else {
+            onError?.(j);
+          }
         }
       } catch {
         // silently retry
@@ -46,10 +53,14 @@ export default function IngestionProgress({
     }
 
     poll(); // immediate first poll
-    timerId = setInterval(poll, 1500);
+    timerRef.current = setInterval(poll, 1500);
 
     return () => {
-      if (timerId) clearInterval(timerId);
+      stopped = true;
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
     };
   }, [jobId]); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## 변경사항
- `timerRef` (useRef)를 도입하여 비동기 클로저에서 최신 timerId 참조
- `stopped` 플래그로 컴포넌트 언마운트 후 상태 업데이트 방지
- completed/failed 감지 즉시 인터벌 취소 보장

## 문제 설명
기존 코드에서 첫 번째 `poll()` 호출 후 `timerId = setInterval(...)`이 비동기적으로 실행되기 전에 poll이 완료되면, poll 내부의 `clearInterval(timerId)`가 null에 대한 no-op이 되어 인터벌이 계속 실행됨.

## QA 결과
- [x] TypeScript 컴파일 통과

Closes #24