### PR TITLE
fix(#28): 계약 상세 페이지 로드 시 기존 분석 결과 자동 로드

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -72,7 +72,20 @@ export default function ContractViewerPage({
   // PDF blob URL (fetched with auth token to avoid 401)
   const [pdfBlobUrl, setPdfBlobUrl] = useState<string | null>(null);
 
-  // ─── Load contract + clauses ────────────────────────────────────────────────
+  // ─── Apply analysis response (defined before useEffects that depend on it) ──
+
+  const applyAnalysisResponse = useCallback((resp: RiskAnalysisResponse) => {
+    setAnalysis(resp.analysis);
+    setClauseResults(resp.clauseResults ?? []);
+    if (
+      resp.analysis.status === "completed" ||
+      resp.analysis.status === "failed"
+    ) {
+      setAnalysisState({ phase: "done", analysisId: resp.analysis.id });
+    }
+  }, []);
+
+  // ─── Load contract + clauses + existing analysis ────────────────────────────
 
   useEffect(() => {
     let blobUrl: string | null = null;
@@ -88,6 +101,24 @@ export default function ContractViewerPage({
         setContract(contractData);
         setClauses(clausesData.clauses ?? []);
         setLoadState("success");
+
+        // Load existing analysis if any (404 = none, which is fine).
+        try {
+          const analysisResp = await api.getLatestAnalysis(contractId);
+          applyAnalysisResponse(analysisResp);
+          // If the analysis is still running, start polling to pick it up.
+          if (
+            analysisResp.analysis.status === "pending" ||
+            analysisResp.analysis.status === "running"
+          ) {
+            setAnalysisState({
+              phase: "polling",
+              analysisId: analysisResp.analysis.id,
+            });
+          }
+        } catch {
+          // No existing analysis — stay idle.
+        }
 
         // Fetch PDF with auth token and create a blob URL for react-pdf.
         const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
@@ -116,20 +147,9 @@ export default function ContractViewerPage({
         setPdfBlobUrl(null);
       }
     };
-  }, [contractId]);
+  }, [contractId, applyAnalysisResponse]);
 
   // ─── Poll analysis status ────────────────────────────────────────────────────
-
-  const applyAnalysisResponse = useCallback((resp: RiskAnalysisResponse) => {
-    setAnalysis(resp.analysis);
-    setClauseResults(resp.clauseResults ?? []);
-    if (
-      resp.analysis.status === "completed" ||
-      resp.analysis.status === "failed"
-    ) {
-      setAnalysisState({ phase: "done", analysisId: resp.analysis.id });
-    }
-  }, []);
 
   useEffect(() => {
     if (analysisState.phase !== "polling") return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -254,6 +254,14 @@ async function getAnalysis(analysisId: string): Promise<RiskAnalysisResponse> {
   return request<RiskAnalysisResponse>(`/risk-analyses/${analysisId}`);
 }
 
+async function getLatestAnalysis(
+  contractId: string
+): Promise<RiskAnalysisResponse> {
+  return request<RiskAnalysisResponse>(
+    `/contracts/${contractId}/risk-analyses`
+  );
+}
+
 async function createOverride(
   analysisId: string,
   clauseResultId: string,
@@ -339,6 +347,7 @@ export const api = {
   // Analysis
   createAnalysis,
   getAnalysis,
+  getLatestAnalysis,
   createOverride,
 
   // Evidence


### PR DESCRIPTION
## 변경사항
- api.ts에 getLatestAnalysis(contractId) 함수 추가
- contracts/[id]/page.tsx 초기 로드 시 기존 분석 자동 조회
  - 완료된 분석: clauseResults + 위험도 하이라이트 즉시 표시
  - 진행 중(pending/running): polling 모드로 자동 전환
  - 분석 없음: idle 유지 (기존 동작)
- applyAnalysisResponse를 useEffect 의존성 선언 전으로 이동 (TS 순서 오류 해소)

## QA 결과
- npx tsc --noEmit 통과

Closes #28