### PR TITLE
fix(#30): CitationCard View Source 잘못된 계약서 로드 버그 수정

### DIFF
--- a/src/components/evidence/CitationCard.tsx
+++ b/src/components/evidence/CitationCard.tsx
@@ -40,14 +40,22 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
   });
 
   async function handleViewSource() {
-    if (citation.type !== "clause" || !contractId) return;
+    if (citation.type !== "clause") return;
+    // Use the source contract ID from the citation (the contract the similar
+    // clause actually came from). Fall back to the current contract if missing.
+    const sourceContractId = citation.source ?? contractId;
+    if (!sourceContractId) return;
+
     setModal({ open: true, content: null, loading: true, error: null });
 
     try {
-      const resp = await api.getSnippets(contractId, 1, 0, 500);
-      const snippets = resp.snippets;
-      const text = snippets.map((s) => s.content).join("\n\n");
-      setModal({ open: true, content: text, loading: false, error: null });
+      const resp = await api.listClauses(sourceContractId);
+      // Find the exact clause referenced by the citation id.
+      const targetClause = resp.clauses.find((c) => c.id === citation.id);
+      const text = targetClause
+        ? targetClause.content
+        : resp.clauses.map((c) => c.content).join("\n\n");
+      setModal({ open: true, content: text || "(no content)", loading: false, error: null });
     } catch {
       setModal({
         open: true,
@@ -91,7 +99,7 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
             {expanded ? "Show less" : "Show more"}
           </button>
 
-          {citation.type === "clause" && contractId && (
+          {citation.type === "clause" && (citation.source ?? contractId) && (
             <button
               onClick={handleViewSource}
               className="text-xs text-zinc-400 hover:text-zinc-600 hover:underline"


### PR DESCRIPTION
## 변경사항
- CitationCard의 View Source 버튼 클릭 시 현재 계약서 대신 citation.source(인용 조항의 원본 계약서 ID)를 사용하도록 수정
- getSnippets(offset 기반 조회) 대신 listClauses로 조항 목록을 가져와 citation.id와 일치하는 정확한 조항을 표시
- citation.source가 없을 경우 contractId(현재 계약서)를 fallback으로 사용
- 일치하는 clause 없을 시 전체 조항 텍스트 fallback 처리

## QA 결과
- build pass (go build ./...)
- TypeScript type check pass (tsc --noEmit)

Closes #30