### PR TITLE
fix(#36): API 에러 메시지 JSON 파싱으로 사용자 친화적 표시

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -127,8 +127,17 @@ async function request<T>(
   }
 
   if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`API ${res.status}: ${body}`);
+    const text = await res.text().catch(() => "");
+    let message = `API error ${res.status}`;
+    if (text) {
+      try {
+        const json = JSON.parse(text) as { error?: string };
+        message = json.error ?? text;
+      } catch {
+        message = text;
+      }
+    }
+    throw new Error(message);
   }
 
   if (res.status === 204) return undefined as unknown as T;


### PR DESCRIPTION
## 변경사항
- `src/lib/api.ts` `request()` 함수의 에러 처리 개선
- HTTP 오류 응답 body를 JSON으로 파싱 후 `error` 필드가 있으면 해당 값을 에러 메시지로 사용
- JSON 파싱 실패 시 원본 텍스트 폴백, 빈 body면 `"API error {status}"` 폴백

## 수정 전/후
- 이전: `API 401: {"error":"email not verified"}` (raw JSON)
- 이후: `email not verified` (사람이 읽기 좋은 메시지)

## QA 결과
- TypeScript 빌드 통과 (`npm run build`)
- 로그인, 회원가입, 비밀번호 재설정 등 모든 에러 경로에 자동 적용

Closes #36