### PR TITLE
fix(#40): Content-Security-Policy 및 보안 헤더 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,50 @@
 import type { NextConfig } from "next";
 
+const API_ORIGIN = "https://signsafe-api.dsmhs.kr";
+
+// Content-Security-Policy directives.
+// - script-src 'unsafe-inline': Next.js requires inline scripts for hydration.
+// - style-src 'unsafe-inline': Tailwind CSS v4 inlines critical styles.
+// - worker-src blob:: PDF.js spawns a Web Worker from a blob URL.
+// - img-src blob: data:: PDF page renders output blob images; data: for base64 avatars.
+// - connect-src: API calls go to signsafe-api; blob: for XHR on local blob objects.
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  `connect-src 'self' ${API_ORIGIN}`,
+  "img-src 'self' data: blob:",
+  "worker-src blob:",
+  "font-src 'self'",
+  "frame-src 'none'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+]
+  .join("; ")
+  .trim();
+
 const nextConfig: NextConfig = {
   output: "standalone",
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes.
+        source: "/(.*)",
+        headers: [
+          { key: "Content-Security-Policy", value: csp },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 변경사항
- `next.config.ts`: `headers()` 함수 추가
- CSP 설정: `script-src 'unsafe-inline'` (Next.js 인라인 스크립트), `worker-src blob:` (PDF.js worker), `connect-src signsafe-api.dsmhs.kr`
- `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy` 추가

## QA 결과
- tsc --noEmit: OK

Closes #40