### PR TITLE
fix(#44): IngestionProgress onComplete/onError stale closure 수정

### DIFF
--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -28,6 +28,15 @@ export default function IngestionProgress({
   // Use a ref so the async poll callback always reads the latest timerId value.
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Store callbacks in refs so the polling closure always invokes the latest
+  // version without requiring a dep-driven effect restart.
+  const onCompleteRef = useRef(onComplete);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+    onErrorRef.current = onError;
+  });
+
   useEffect(() => {
     let stopped = false;
 
@@ -42,9 +51,9 @@ export default function IngestionProgress({
             timerRef.current = null;
           }
           if (j.status === "completed") {
-            onComplete?.(j);
+            onCompleteRef.current?.(j);
           } else {
-            onError?.(j);
+            onErrorRef.current?.(j);
           }
         }
       } catch {
@@ -62,7 +71,7 @@ export default function IngestionProgress({
         timerRef.current = null;
       }
     };
-  }, [jobId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [jobId]);
 
   if (!job) {
     return (
@@ -74,8 +83,7 @@ export default function IngestionProgress({
   }
 
   const progress = job.progress ?? 0;
-  const label =
-    STEP_LABELS[job.status] ?? job.status;
+  const label = STEP_LABELS[job.status] ?? job.status;
 
   const isFailed = job.status === "failed";
   const isComplete = job.status === "completed";


### PR DESCRIPTION
## 변경사항
- `onCompleteRef`/`onErrorRef`를 `useRef`로 관리하여 항상 최신 콜백 참조
- 매 렌더에서 ref를 동기화하는 `useEffect` 추가
- polling `useEffect`의 `eslint-disable-line react-hooks/exhaustive-deps` 제거

## QA 결과
- tsc --noEmit: OK

Closes #44