### PR TITLE
fix(#46): 파일 업로드 진행률 표시 추가 (XHR onprogress)

### DIFF
--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -62,6 +62,7 @@ export default function ContractsPage() {
 
   const [activeUploads, setActiveUploads] = useState<ActiveUpload[]>([]);
   const [uploading, setUploading] = useState(false);
+  const [uploadPercent, setUploadPercent] = useState(0);
   const [uploadTitle, setUploadTitle] = useState("");
   const [showUpload, setShowUpload] = useState(false);
 
@@ -91,13 +92,14 @@ export default function ContractsPage() {
 
   async function handleFile(file: File) {
     setUploading(true);
+    setUploadPercent(0);
     try {
       const formData = new FormData();
       formData.append("file", file);
       formData.append("organizationId", orgId);
       if (uploadTitle) formData.append("title", uploadTitle);
 
-      const result = await api.uploadContract(formData);
+      const result = await api.uploadContractWithProgress(formData, setUploadPercent);
       setActiveUploads((prev) => [
         ...prev,
         {
@@ -115,6 +117,7 @@ export default function ContractsPage() {
       );
     } finally {
       setUploading(false);
+      setUploadPercent(0);
     }
   }
 
@@ -184,7 +187,18 @@ export default function ContractsPage() {
           </div>
           <DropZone onFile={handleFile} disabled={uploading} />
           {uploading && (
-            <p className="text-sm text-zinc-500">Uploading…</p>
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between text-xs text-zinc-500">
+                <span>Uploading…</span>
+                <span>{uploadPercent}%</span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-200">
+                <div
+                  className="h-full rounded-full bg-zinc-700 transition-all duration-150"
+                  style={{ width: `${uploadPercent}%` }}
+                />
+              </div>
+            </div>
           )}
         </div>
       )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -228,6 +228,72 @@ async function uploadContract(
   });
 }
 
+/**
+ * Upload a contract and report upload progress via onProgress callback.
+ * Uses XMLHttpRequest so that the upload.onprogress event fires.
+ * Handles 401 → token refresh → retry automatically.
+ */
+async function uploadContractWithProgress(
+  formData: FormData,
+  onProgress: (percent: number) => void
+): Promise<UploadContractResponse> {
+  function xhrUpload(token: string | null): Promise<UploadContractResponse> {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open("POST", `${API_URL}/contracts`);
+      xhr.withCredentials = true;
+      if (token) {
+        xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+      }
+
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) {
+          onProgress(Math.round((e.loaded / e.total) * 100));
+        }
+      };
+
+      xhr.onload = () => {
+        if (xhr.status === 200 || xhr.status === 201) {
+          try {
+            resolve(JSON.parse(xhr.responseText) as UploadContractResponse);
+          } catch {
+            reject(new Error("Failed to parse upload response"));
+          }
+        } else {
+          let message = `API error ${xhr.status}`;
+          try {
+            const json = JSON.parse(xhr.responseText) as { error?: string };
+            message = json.error ?? message;
+          } catch {
+            /* ignore */
+          }
+          reject(Object.assign(new Error(message), { status: xhr.status }));
+        }
+      };
+
+      xhr.onerror = () => reject(new Error("Network error during upload"));
+      xhr.send(formData);
+    });
+  }
+
+  try {
+    return await xhrUpload(getAccessToken());
+  } catch (err: unknown) {
+    // Retry once after refreshing the token on 401.
+    const status = (err as { status?: number }).status;
+    if (status === 401) {
+      const refreshed = await refreshAccessToken();
+      if (!refreshed) {
+        clearAuth();
+        redirectToLogin();
+        return new Promise(() => {});
+      }
+      return xhrUpload(getAccessToken());
+    }
+    throw err;
+  }
+}
+
 async function deleteContract(contractId: string): Promise<void> {
   return request<void>(`/contracts/${contractId}`, { method: "DELETE" });
 }
@@ -364,6 +430,7 @@ export const api = {
   listContracts,
   getContract,
   uploadContract,
+  uploadContractWithProgress,
   deleteContract,
   updateContract,
   getIngestionJob,


### PR DESCRIPTION
## 변경사항
- `api.ts`: `uploadContractWithProgress(formData, onProgress)` XHR 기반 함수 추가 — 401 시 refresh 후 재시도
- `contracts/page.tsx`: `uploadPercent` state 추가 및 업로드 중 프로그레스 바 표시

## QA 결과
- tsc --noEmit: OK

Closes #46