### PR TITLE
fix(#50): show "Processing…" instead of "Uploading…" during ingestion poll

### DIFF
--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -74,10 +74,12 @@ export default function IngestionProgress({
   }, [jobId]);
 
   if (!job) {
+    // File upload is already done at this point — we are waiting for the first
+    // ingestion job poll to return. "Uploading…" is therefore misleading.
     return (
       <div className="flex items-center gap-2 text-sm text-zinc-500">
         <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600" />
-        <span>Uploading…</span>
+        <span>Processing…</span>
       </div>
     );
   }


### PR DESCRIPTION
## 변경사항
- `IngestionProgress.tsx`: `job === null`인 초기 상태에서 "Uploading…" → "Processing…"으로 레이블 변경

## 문제 설명
`IngestionProgress` 컴포넌트가 마운트될 때는 파일 업로드가 이미 완료된 상태입니다.
`job`이 null인 순간은 첫 번째 API 폴링 응답을 기다리는 중이지, 업로드 중이 아닙니다.
"Uploading…" 텍스트는 사용자에게 혼란을 줍니다.

## QA 결과
- `tsc --noEmit` → 오류 없음

Closes #50