### PR TITLE
feat(#53): 분석 완료/실패 후 Re-analyze 버튼 추가

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -276,9 +276,15 @@ export default function ContractViewerPage({
   const analysisButtonLabel = () => {
     if (analysisState.phase === "requesting") return "Starting…";
     if (analysisState.phase === "polling") return "Analyzing…";
-    if (analysis?.status === "completed") return "Analysis complete";
     return "AI Risk Analysis";
   };
+
+  // Show "Re-analyze" when a previous analysis exists and is completed or failed,
+  // AND no new analysis is currently in flight.
+  const showReanalyzeButton =
+    !isAnalysisRunning &&
+    (analysis?.status === "completed" || analysis?.status === "failed") &&
+    loadState === "success";
 
   // Use the authenticated blob URL for the PDF viewer.
   const pdfUrl = pdfBlobUrl;
@@ -356,20 +362,25 @@ export default function ContractViewerPage({
               </button>
             )}
 
-            <button
-              onClick={handleRequestAnalysis}
-              disabled={
-                isAnalysisRunning ||
-                analysis?.status === "completed" ||
-                loadState !== "success"
-              }
-              className="flex items-center gap-1.5 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {isAnalysisRunning && (
-                <div className="h-3 w-3 animate-spin rounded-full border border-white/40 border-t-white" />
-              )}
-              {analysisButtonLabel()}
-            </button>
+            {showReanalyzeButton ? (
+              <button
+                onClick={handleRequestAnalysis}
+                className="flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
+              >
+                Re-analyze
+              </button>
+            ) : (
+              <button
+                onClick={handleRequestAnalysis}
+                disabled={isAnalysisRunning || loadState !== "success"}
+                className="flex items-center gap-1.5 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isAnalysisRunning && (
+                  <div className="h-3 w-3 animate-spin rounded-full border border-white/40 border-t-white" />
+                )}
+                {analysisButtonLabel()}
+              </button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## 변경사항
- `analysis.status === 'completed'` 또는 `'failed'`이고 분석이 실행 중이 아닐 때 "Re-analyze" 버튼 표시
- Re-analyze 클릭 시 `handleRequestAnalysis`를 통해 새 분석 요청 후 폴링 재시작
- 기존 "AI Risk Analysis" 버튼은 최초 분석(no previous analysis) 시에만 표시
- 분석 진행 중(`requesting` / `polling` / `running`)에는 Re-analyze 버튼 숨김

## QA 결과
- [ ] 분석 완료 후 "Re-analyze" 버튼 표시 확인
- [ ] 분석 실패 후 "Re-analyze" 버튼 표시 확인
- [ ] Re-analyze 클릭 → 새 분석 시작 및 폴링 확인
- [ ] 분석 진행 중 버튼 숨김 확인
- TypeScript 타입 체크 통과

Closes #53