### PR TITLE
feat(#56): add loading.tsx skeletons for (app) and contracts route segments

### DIFF
--- a/src/app/(app)/contracts/loading.tsx
+++ b/src/app/(app)/contracts/loading.tsx
@@ -1,0 +1,25 @@
+/**
+ * Loading skeleton for the contracts list page.
+ * Shown while the server streams the contracts list.
+ */
+export default function ContractsLoading() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="mb-6 h-7 w-48 animate-pulse rounded-md bg-zinc-200" />
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between rounded-lg border border-zinc-100 bg-white p-4 shadow-sm"
+          >
+            <div className="space-y-2">
+              <div className="h-4 w-56 animate-pulse rounded bg-zinc-200" />
+              <div className="h-3 w-32 animate-pulse rounded bg-zinc-100" />
+            </div>
+            <div className="h-6 w-20 animate-pulse rounded-full bg-zinc-100" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,0 +1,11 @@
+/**
+ * Top-level loading skeleton for the (app) route group.
+ * Shown while any page inside (app) is streaming its initial server render.
+ */
+export default function AppLoading() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-200 border-t-zinc-900" />
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경사항
- `src/app/(app)/loading.tsx` 추가 — 앱 레벨 Suspense fallback (스피너)
- `src/app/(app)/contracts/loading.tsx` 추가 — 계약 목록 skeleton UI

## 이유
loading.tsx 없이는 서버 스트리밍 중 빈 화면 표시. Next.js App Router의 `loading.tsx` 컨벤션으로 즉각적인 피드백 제공.

## QA 결과
- `tsc --noEmit` 통과

Closes #56