### PR TITLE
feat(#57): add root not-found.tsx for 404 handling

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+/**
+ * Root not-found page.
+ * Rendered when notFound() is called anywhere in the app, or when a URL
+ * does not match any route. Next.js returns HTTP 404 for non-streamed responses.
+ */
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100">
+        <span className="text-2xl font-bold text-zinc-400">404</span>
+      </div>
+
+      <div className="space-y-1">
+        <h1 className="text-base font-semibold text-zinc-900">
+          Page not found
+        </h1>
+        <p className="text-sm text-zinc-500">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+      </div>
+
+      <Link
+        href="/contracts"
+        className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+      >
+        Go to contracts
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경사항
- `src/app/not-found.tsx` 추가 — 앱 전체 404 페이지

## 이유
not-found.tsx 없이는 Next.js 기본 404 페이지가 표시되어 디자인 일관성이 없고, `notFound()` 호출 시 커스텀 UI를 제공할 수 없음.

## QA 결과
- `tsc --noEmit` 통과

Closes #57