### PR TITLE
fix(#62): /auth/* 401 응답이 인터셉터에 걸려 로그인 리다이렉트 유발

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -115,7 +115,9 @@ async function request<T>(
     credentials: "include",
   });
 
-  if (res.status === 401 && !isRetry) {
+  // Auth endpoints manage their own credentials — never intercept their 401s.
+  const isAuthEndpoint = path.startsWith("/auth/");
+  if (res.status === 401 && !isRetry && !isAuthEndpoint) {
     const refreshed = await refreshAccessToken();
     if (!refreshed) {
       clearAuth();


### PR DESCRIPTION
## 버그
로그인 실패(잘못된 비밀번호, 미인증 이메일) 시 에러 메시지가 표시되지 않고 페이지가 새로고침됨.

## 원인
`request()`의 401 인터셉터가 `/auth/login` 응답도 가로채 refresh 시도 → 실패 → `redirectToLogin()` 호출

## 수정
`/auth/*` 경로는 `isAuthEndpoint` 플래그로 인터셉터 skip — 에러가 caller까지 정상 전파됨

## QA
- TypeScript 타입 체크 통과

Closes #62