### PR TITLE
feat(#70): Toast 알림 시스템, 설정 페이지, 멤버 관리, 분석 폴링 UX

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/types";
 import ClauseNav from "@/components/viewer/ClauseNav";
 import dynamic from "next/dynamic";
+import { useToast } from "@/components/ui/Toast";
 
 // Dynamically import the DocumentViewer to avoid SSR issues with react-pdf.
 const DocumentViewer = dynamic(
@@ -43,6 +44,7 @@ export default function ContractViewerPage({
 }) {
   const { id: contractId } = use(params);
   const router = useRouter();
+  const { toast } = useToast();
 
   // Scroll target map: page-{n} → div element
   const scrollTargetRef = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -81,16 +83,26 @@ export default function ContractViewerPage({
 
   // ─── Apply analysis response (defined before useEffects that depend on it) ──
 
-  const applyAnalysisResponse = useCallback((resp: RiskAnalysisResponse) => {
-    setAnalysis(resp.analysis);
-    setClauseResults(resp.clauseResults ?? []);
-    if (
-      resp.analysis.status === "completed" ||
-      resp.analysis.status === "failed"
-    ) {
-      setAnalysisState({ phase: "done", analysisId: resp.analysis.id });
-    }
-  }, []);
+  const applyAnalysisResponse = useCallback(
+    (resp: RiskAnalysisResponse, notify = false) => {
+      setAnalysis(resp.analysis);
+      setClauseResults(resp.clauseResults ?? []);
+      if (
+        resp.analysis.status === "completed" ||
+        resp.analysis.status === "failed"
+      ) {
+        setAnalysisState({ phase: "done", analysisId: resp.analysis.id });
+        if (notify) {
+          if (resp.analysis.status === "completed") {
+            toast("success", `Analysis complete — ${(resp.clauseResults ?? []).length} clauses reviewed.`);
+          } else {
+            toast("error", "Analysis failed. Please try again.");
+          }
+        }
+      }
+    },
+    [toast]
+  );
 
   // ─── Load contract + clauses + existing analysis ────────────────────────────
 
@@ -167,7 +179,7 @@ export default function ContractViewerPage({
     async function poll() {
       try {
         const resp = await api.getAnalysis(analysisId);
-        applyAnalysisResponse(resp);
+        applyAnalysisResponse(resp, true);
         if (
           resp.analysis.status === "completed" ||
           resp.analysis.status === "failed"
@@ -223,6 +235,7 @@ export default function ContractViewerPage({
       const updated = await api.updateContract(contractId, payload);
       setContract(updated);
       setShowEditModal(false);
+      toast("success", "Contract updated.");
     } catch (err: unknown) {
       setEditError(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
     } finally {
@@ -238,11 +251,7 @@ export default function ContractViewerPage({
       const resp = await api.createAnalysis(contractId);
       setAnalysisState({ phase: "polling", analysisId: resp.analysisId });
     } catch (err: unknown) {
-      alert(
-        `Failed to start analysis: ${
-          err instanceof Error ? err.message : "Unknown error"
-        }`
-      );
+      toast("error", `Failed to start analysis: ${err instanceof Error ? err.message : "Unknown error"}`);
       setAnalysisState({ phase: "idle" });
     }
   }

--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -7,6 +7,7 @@ import { api } from "@/lib/api";
 import type { Contract, IngestionJob } from "@/types";
 import DropZone from "@/components/upload/DropZone";
 import IngestionProgress from "@/components/upload/IngestionProgress";
+import { useToast } from "@/components/ui/Toast";
 
 interface DeleteDialogState {
   open: boolean;
@@ -51,6 +52,7 @@ function formatDate(iso: string) {
 
 export default function ContractsPage() {
   const user = useAuthStore((s) => s.user);
+  const { toast } = useToast();
 
   const orgId = user?.organizationId ?? "";
 
@@ -132,9 +134,7 @@ export default function ContractsPage() {
       setShowUpload(false);
       fetchContracts();
     } catch (err: unknown) {
-      alert(
-        `Upload failed: ${err instanceof Error ? err.message : "Unknown error"}`
-      );
+      toast("error", `Upload failed: ${err instanceof Error ? err.message : "Unknown error"}`);
     } finally {
       setUploading(false);
       setUploadPercent(0);
@@ -145,9 +145,9 @@ export default function ContractsPage() {
     setActiveUploads((prev) =>
       prev.map((u) => (u.jobId === jobId ? { ...u, done: true } : u))
     );
-    // Refresh list after ingestion completes
     fetchContracts();
     void job;
+    toast("success", "Document processed and ready for analysis.");
   }
 
   function openDeleteDialog(e: React.MouseEvent, contract: Contract) {
@@ -163,7 +163,7 @@ export default function ContractsPage() {
       setDeleteDialog({ open: false, contractId: "", contractTitle: "" });
       fetchContracts();
     } catch (err: unknown) {
-      alert(`Delete failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      toast("error", `Delete failed: ${err instanceof Error ? err.message : "Unknown error"}`);
     } finally {
       setDeleting(false);
     }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -68,6 +68,12 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               {user.fullName}
             </span>
           )}
+          <Link
+            href="/settings"
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-50"
+          >
+            Settings
+          </Link>
           <button
             onClick={handleLogout}
             className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-50"

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useAuthStore } from "@/lib/auth";
+import { api } from "@/lib/api";
+import type { MemberInfo } from "@/types";
+import { useToast } from "@/components/ui/Toast";
+
+type Tab = "profile" | "organization" | "members";
+
+export default function SettingsPage() {
+  const { toast } = useToast();
+  const { user, setAuth, accessToken } = useAuthStore();
+  const orgId = user?.organizationId ?? "";
+
+  const [tab, setTab] = useState<Tab>("profile");
+
+  // ── Profile ──────────────────────────────────────────────────────────────
+  const [profileName, setProfileName] = useState(user?.fullName ?? "");
+  const [profileSaving, setProfileSaving] = useState(false);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordSaving, setPasswordSaving] = useState(false);
+
+  async function handleSaveProfile() {
+    if (!profileName.trim()) {
+      toast("error", "Name cannot be empty.");
+      return;
+    }
+    setProfileSaving(true);
+    try {
+      const updated = await api.updateProfile(profileName.trim());
+      if (user) {
+        setAuth(accessToken ?? "", { ...user, fullName: updated.fullName });
+      }
+      toast("success", "Profile updated.");
+    } catch (err: unknown) {
+      toast("error", err instanceof Error ? err.message : "Failed to update profile.");
+    } finally {
+      setProfileSaving(false);
+    }
+  }
+
+  async function handleChangePassword() {
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      toast("error", "All password fields are required.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast("error", "New passwords do not match.");
+      return;
+    }
+    if (newPassword.length < 8) {
+      toast("error", "New password must be at least 8 characters.");
+      return;
+    }
+    setPasswordSaving(true);
+    try {
+      await api.changePassword(currentPassword, newPassword);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      toast("success", "Password changed successfully.");
+    } catch (err: unknown) {
+      toast("error", err instanceof Error ? err.message : "Failed to change password.");
+    } finally {
+      setPasswordSaving(false);
+    }
+  }
+
+  // ── Organization ─────────────────────────────────────────────────────────
+  const [orgName, setOrgName] = useState("");
+  const [orgPlan, setOrgPlan] = useState("");
+  const [orgLoading, setOrgLoading] = useState(false);
+  const [orgSaving, setOrgSaving] = useState(false);
+
+  useEffect(() => {
+    if (tab !== "organization" && tab !== "members") return;
+    if (!orgId) return;
+    setOrgLoading(true);
+    api.getOrganization(orgId)
+      .then((org) => {
+        setOrgName(org.name);
+        setOrgPlan(org.plan);
+      })
+      .catch(() => toast("error", "Failed to load organization."))
+      .finally(() => setOrgLoading(false));
+  }, [tab, orgId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleSaveOrg() {
+    if (!orgName.trim()) {
+      toast("error", "Organization name cannot be empty.");
+      return;
+    }
+    setOrgSaving(true);
+    try {
+      await api.updateOrganization(orgId, orgName.trim());
+      toast("success", "Organization name updated.");
+    } catch (err: unknown) {
+      toast("error", err instanceof Error ? err.message : "Failed to update organization.");
+    } finally {
+      setOrgSaving(false);
+    }
+  }
+
+  // ── Members ───────────────────────────────────────────────────────────────
+  const [members, setMembers] = useState<MemberInfo[]>([]);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState("member");
+  const [inviting, setInviting] = useState(false);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  const fetchMembers = () => {
+    if (!orgId) return;
+    setMembersLoading(true);
+    api.listMembers(orgId)
+      .then((res) => setMembers(res.members))
+      .catch(() => toast("error", "Failed to load members."))
+      .finally(() => setMembersLoading(false));
+  };
+
+  useEffect(() => {
+    if (tab !== "members") return;
+    fetchMembers();
+  }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleInvite() {
+    if (!inviteEmail.trim()) {
+      toast("error", "Email is required.");
+      return;
+    }
+    setInviting(true);
+    try {
+      await api.inviteMember(orgId, inviteEmail.trim(), inviteRole);
+      setInviteEmail("");
+      toast("success", `${inviteEmail} added to organization.`);
+      fetchMembers();
+    } catch (err: unknown) {
+      toast("error", err instanceof Error ? err.message : "Failed to invite member.");
+    } finally {
+      setInviting(false);
+    }
+  }
+
+  async function handleRemove(targetUserId: string) {
+    setRemoving(targetUserId);
+    try {
+      await api.removeMember(orgId, targetUserId);
+      setMembers((prev) => prev.filter((m) => m.userId !== targetUserId));
+      toast("success", "Member removed.");
+    } catch (err: unknown) {
+      toast("error", err instanceof Error ? err.message : "Failed to remove member.");
+    } finally {
+      setRemoving(null);
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const tabClass = (t: Tab) =>
+    `px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+      tab === t
+        ? "bg-zinc-900 text-white"
+        : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100"
+    }`;
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-6 py-8 space-y-6">
+      <h1 className="text-2xl font-bold text-zinc-900">Settings</h1>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 rounded-lg bg-zinc-100 p-1 w-fit">
+        <button onClick={() => setTab("profile")} className={tabClass("profile")}>
+          Profile
+        </button>
+        <button onClick={() => setTab("organization")} className={tabClass("organization")}>
+          Organization
+        </button>
+        <button onClick={() => setTab("members")} className={tabClass("members")}>
+          Members
+        </button>
+      </div>
+
+      {/* Profile tab */}
+      {tab === "profile" && (
+        <div className="space-y-6">
+          {/* Display name */}
+          <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">Display name</h2>
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-zinc-700">Full name</label>
+              <input
+                type="text"
+                value={profileName}
+                onChange={(e) => setProfileName(e.target.value)}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+              />
+            </div>
+            <div className="flex justify-end">
+              <button
+                onClick={handleSaveProfile}
+                disabled={profileSaving}
+                className="flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+              >
+                {profileSaving && (
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border border-white/40 border-t-white" />
+                )}
+                {profileSaving ? "Saving…" : "Save name"}
+              </button>
+            </div>
+          </section>
+
+          {/* Change password */}
+          <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">Change password</h2>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">Current password</label>
+                <input
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  autoComplete="current-password"
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">New password</label>
+                <input
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  autoComplete="new-password"
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">Confirm new password</label>
+                <input
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+                />
+              </div>
+            </div>
+            <div className="flex justify-end">
+              <button
+                onClick={handleChangePassword}
+                disabled={passwordSaving}
+                className="flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+              >
+                {passwordSaving && (
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border border-white/40 border-t-white" />
+                )}
+                {passwordSaving ? "Saving…" : "Change password"}
+              </button>
+            </div>
+          </section>
+
+          {/* Account info (read-only) */}
+          <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm space-y-3">
+            <h2 className="text-base font-semibold text-zinc-900">Account info</h2>
+            <div className="text-sm text-zinc-600 space-y-1">
+              <p><span className="font-medium text-zinc-800">Email:</span> {user?.email}</p>
+              <p><span className="font-medium text-zinc-800">Role:</span> {user?.role}</p>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {/* Organization tab */}
+      {tab === "organization" && (
+        <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm space-y-4">
+          <h2 className="text-base font-semibold text-zinc-900">Organization</h2>
+          {orgLoading ? (
+            <div className="flex items-center justify-center py-10">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+            </div>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-zinc-700">Organization name</label>
+                <input
+                  type="text"
+                  value={orgName}
+                  onChange={(e) => setOrgName(e.target.value)}
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+                />
+              </div>
+              <div className="text-sm text-zinc-500">
+                Plan: <span className="font-medium text-zinc-700 capitalize">{orgPlan || "free"}</span>
+              </div>
+              <div className="flex justify-end">
+                <button
+                  onClick={handleSaveOrg}
+                  disabled={orgSaving}
+                  className="flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+                >
+                  {orgSaving && (
+                    <div className="h-3.5 w-3.5 animate-spin rounded-full border border-white/40 border-t-white" />
+                  )}
+                  {orgSaving ? "Saving…" : "Save"}
+                </button>
+              </div>
+            </>
+          )}
+        </section>
+      )}
+
+      {/* Members tab */}
+      {tab === "members" && (
+        <div className="space-y-4">
+          {/* Invite form */}
+          <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">Invite member</h2>
+            <div className="flex gap-2">
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="user@example.com"
+                onKeyDown={(e) => e.key === "Enter" && handleInvite()}
+                className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+              />
+              <select
+                value={inviteRole}
+                onChange={(e) => setInviteRole(e.target.value)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+              >
+                <option value="member">Member</option>
+                <option value="reviewer">Reviewer</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                onClick={handleInvite}
+                disabled={inviting}
+                className="flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 whitespace-nowrap"
+              >
+                {inviting && (
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border border-white/40 border-t-white" />
+                )}
+                {inviting ? "Adding…" : "Add"}
+              </button>
+            </div>
+            <p className="text-xs text-zinc-400">
+              The user must already have a SignSafe account.
+            </p>
+          </section>
+
+          {/* Members list */}
+          <section className="rounded-xl border border-zinc-200 bg-white shadow-sm overflow-hidden">
+            {membersLoading ? (
+              <div className="flex items-center justify-center py-10">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+              </div>
+            ) : members.length === 0 ? (
+              <p className="p-6 text-sm text-zinc-400 text-center">No members found.</p>
+            ) : (
+              <ul className="divide-y divide-zinc-100">
+                {members.map((m) => (
+                  <li key={m.userId} className="flex items-center justify-between px-6 py-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-zinc-900 truncate">{m.fullName}</p>
+                      <p className="text-xs text-zinc-400 truncate">{m.email}</p>
+                    </div>
+                    <div className="flex items-center gap-3 ml-4">
+                      <span className="text-xs rounded-full bg-zinc-100 px-2.5 py-0.5 text-zinc-600 capitalize">
+                        {m.role}
+                      </span>
+                      {m.userId !== user?.id && (
+                        <button
+                          onClick={() => handleRemove(m.userId)}
+                          disabled={removing === m.userId}
+                          className="text-xs text-zinc-400 hover:text-red-500 transition-colors disabled:opacity-40"
+                        >
+                          {removing === m.userId ? "Removing…" : "Remove"}
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,18 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-slide-in {
+  animation: slide-in 0.18s ease-out forwards;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ToastProvider } from "@/components/ui/Toast";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,7 +32,9 @@ export default function RootLayout({
       lang="ko"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+
+export type ToastType = "success" | "error" | "info";
+
+interface Toast {
+  id: number;
+  type: ToastType;
+  message: string;
+}
+
+interface ToastContextValue {
+  toast: (type: ToastType, message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let _nextId = 1;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback((type: ToastType, message: string) => {
+    const id = _nextId++;
+    setToasts((prev) => [...prev, { id, type, message }]);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none">
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: (id: number) => void;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => onDismiss(toast.id), 4000);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [toast.id, onDismiss]);
+
+  const base =
+    "pointer-events-auto flex items-start gap-3 rounded-lg px-4 py-3 shadow-lg text-sm font-medium max-w-sm w-full animate-slide-in";
+
+  const styles: Record<ToastType, string> = {
+    success: `${base} bg-green-50 text-green-800 ring-1 ring-green-200`,
+    error: `${base} bg-red-50 text-red-800 ring-1 ring-red-200`,
+    info: `${base} bg-zinc-900 text-white`,
+  };
+
+  const icons: Record<ToastType, React.ReactNode> = {
+    success: (
+      <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+      </svg>
+    ),
+    error: (
+      <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    ),
+    info: (
+      <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-zinc-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  };
+
+  return (
+    <div className={styles[toast.type]}>
+      {icons[toast.type]}
+      <span className="flex-1 leading-5">{toast.message}</span>
+      <button
+        onClick={() => onDismiss(toast.id)}
+        className="ml-auto flex-shrink-0 opacity-50 hover:opacity-100 transition-opacity"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used inside ToastProvider");
+  return ctx;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,9 @@ import type {
   LoginResponse,
   SignupResponse,
   User,
+  Organization,
+  MemberInfo,
+  MembersResponse,
   Contract,
   ContractListResponse,
   UploadContractResponse,
@@ -210,6 +213,61 @@ async function resetPassword(
 
 async function getMe(): Promise<User> {
   return request<User>("/users/me");
+}
+
+async function updateProfile(fullName: string): Promise<User> {
+  return request<User>("/users/me", {
+    method: "PATCH",
+    body: JSON.stringify({ fullName }),
+  });
+}
+
+async function changePassword(
+  currentPassword: string,
+  newPassword: string
+): Promise<{ message: string }> {
+  return request<{ message: string }>("/users/me/password", {
+    method: "PATCH",
+    body: JSON.stringify({ currentPassword, newPassword }),
+  });
+}
+
+async function getOrganization(orgId: string): Promise<Organization> {
+  return request<Organization>(`/organizations/${orgId}`);
+}
+
+async function updateOrganization(
+  orgId: string,
+  name: string
+): Promise<Organization> {
+  return request<Organization>(`/organizations/${orgId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ name }),
+  });
+}
+
+async function listMembers(orgId: string): Promise<MembersResponse> {
+  return request<MembersResponse>(`/organizations/${orgId}/members`);
+}
+
+async function inviteMember(
+  orgId: string,
+  email: string,
+  role = "member"
+): Promise<{ message: string }> {
+  return request<{ message: string }>(`/organizations/${orgId}/members`, {
+    method: "POST",
+    body: JSON.stringify({ email, role }),
+  });
+}
+
+async function removeMember(
+  orgId: string,
+  userId: string
+): Promise<void> {
+  return request<void>(`/organizations/${orgId}/members/${userId}`, {
+    method: "DELETE",
+  });
 }
 
 // ─────────────────────────────────────────────
@@ -437,6 +495,15 @@ export const api = {
   forgotPassword,
   resetPassword,
   getMe,
+  updateProfile,
+  changePassword,
+
+  // Organization
+  getOrganization,
+  updateOrganization,
+  listMembers,
+  inviteMember,
+  removeMember,
 
   // Contracts
   listContracts,
@@ -468,3 +535,4 @@ export { request };
 
 // Re-export Clause type parsed from ClauseResult for convenience.
 export type { Clause };
+export type { MemberInfo, MembersResponse };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,19 @@ export interface Organization {
   updatedAt: string;
 }
 
+export interface MemberInfo {
+  userId: string;
+  email: string;
+  fullName: string;
+  role: string;
+  joinedAt: string;
+}
+
+export interface MembersResponse {
+  members: MemberInfo[];
+  total: number;
+}
+
 // ─────────────────────────────────────────────
 // Contract
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## 변경사항

- **Toast 알림**: alert() 전부 제거, success/error/info toast 컴포넌트 추가
- **설정 페이지** `/settings`: Profile (이름·비밀번호) / Organization (이름) / Members (초대·제거) 탭
- **분석 UX**: 완료·실패 시 toast 알림, 인게스션 완료 toast
- **네비게이션**: Settings 링크 추가
- **API 클라이언트**: 프로필/조직/멤버 CRUD 메서드 추가

## QA 결과

- TypeScript `tsc --noEmit` 통과
- Toast 메모리 누수 없음 (cleanup 구현)
- `any` 타입 없음
- 모든 async 핸들러 try/catch + toast 에러 처리

Closes #70