### PR TITLE
feat(#73): 네비게이션 조직명 표시 및 멤버 역할 변경 UI

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -63,6 +63,11 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         </nav>
 
         <div className="flex items-center gap-3">
+          {user?.organizationName && (
+            <span className="hidden sm:inline-flex items-center rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-600 border border-zinc-200">
+              {user.organizationName}
+            </span>
+          )}
           {user && (
             <span className="text-sm text-zinc-500 hidden sm:inline">
               {user.fullName}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -112,6 +112,7 @@ export default function SettingsPage() {
   const [inviteRole, setInviteRole] = useState("member");
   const [inviting, setInviting] = useState(false);
   const [removing, setRemoving] = useState<string | null>(null);
+  const [updatingRole, setUpdatingRole] = useState<string | null>(null);
 
   const fetchMembers = () => {
     if (!orgId) return;
@@ -155,6 +156,24 @@ export default function SettingsPage() {
       toast("error", err instanceof Error ? err.message : "Failed to remove member.");
     } finally {
       setRemoving(null);
+    }
+  }
+
+  async function handleRoleChange(
+    targetUserId: string,
+    newRole: "admin" | "member" | "reviewer"
+  ) {
+    setUpdatingRole(targetUserId);
+    try {
+      await api.updateMemberRole(orgId, targetUserId, newRole);
+      setMembers((prev) =>
+        prev.map((m) => (m.userId === targetUserId ? { ...m, role: newRole } : m))
+      );
+      toast("success", "Role updated.");
+    } catch (err: unknown) {
+      toast("error", err instanceof Error ? err.message : "Failed to update role.");
+    } finally {
+      setUpdatingRole(null);
     }
   }
 
@@ -369,9 +388,27 @@ export default function SettingsPage() {
                       <p className="text-xs text-zinc-400 truncate">{m.email}</p>
                     </div>
                     <div className="flex items-center gap-3 ml-4">
-                      <span className="text-xs rounded-full bg-zinc-100 px-2.5 py-0.5 text-zinc-600 capitalize">
-                        {m.role}
-                      </span>
+                      {m.userId === user?.id ? (
+                        <span className="text-xs rounded-full bg-zinc-100 px-2.5 py-0.5 text-zinc-600 capitalize">
+                          {m.role}
+                        </span>
+                      ) : (
+                        <select
+                          value={m.role}
+                          onChange={(e) =>
+                            handleRoleChange(
+                              m.userId,
+                              e.target.value as "admin" | "member" | "reviewer"
+                            )
+                          }
+                          disabled={updatingRole === m.userId}
+                          className="rounded-md border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-xs text-zinc-700 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 disabled:opacity-40 capitalize"
+                        >
+                          <option value="member">Member</option>
+                          <option value="reviewer">Reviewer</option>
+                          <option value="admin">Admin</option>
+                        </select>
+                      )}
                       {m.userId !== user?.id && (
                         <button
                           onClick={() => handleRemove(m.userId)}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -270,6 +270,20 @@ async function removeMember(
   });
 }
 
+async function updateMemberRole(
+  orgId: string,
+  userId: string,
+  role: "admin" | "member" | "reviewer"
+): Promise<{ message: string }> {
+  return request<{ message: string }>(
+    `/organizations/${orgId}/members/${userId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ role }),
+    }
+  );
+}
+
 // ─────────────────────────────────────────────
 // Contract endpoints
 // ─────────────────────────────────────────────
@@ -504,6 +518,7 @@ export const api = {
   listMembers,
   inviteMember,
   removeMember,
+  updateMemberRole,
 
   // Contracts
   listContracts,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export interface User {
   createdAt: string;
   permissions: string[];
   organizationId: string;
+  organizationName?: string;
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## 변경사항

- `src/types/index.ts`: `User` 인터페이스에 `organizationName?: string` 추가
- `src/lib/api.ts`: `updateMemberRole(orgId, userId, role)` 함수 추가 (`PATCH /organizations/:id/members/:userId`)
- `src/app/(app)/layout.tsx`: 헤더에 조직명 뱃지 표시 (`user.organizationName` 존재 시)
- `src/app/(app)/settings/page.tsx`: Members 탭 역할 변경 드롭다운 UI 추가

## 상세 동작

### Task #14 — 네비게이션 조직명 표시
- `GET /users/me` 응답의 `organizationName` 필드를 auth store의 `user` 객체에 저장
- 헤더 우측 사용자명 앞에 `bg-zinc-100` 둥근 뱃지로 조직명 표시
- `organizationName`이 없는 경우(기존 토큰 등) 뱃지 미표시

### Task #15 — 멤버 역할 변경 UI
- 자기 자신: 읽기 전용 뱃지 (변경 불가)
- 타 멤버: `admin / member / reviewer` 선택 드롭다운
- 변경 중 `disabled` 처리로 중복 요청 방지
- 성공 시 로컬 `members` 상태를 즉시 갱신 + Toast "Role updated"
- 실패 시 Toast 에러 메시지 표시

## QA 결과

- `npm run build` 통과 (TypeScript, 빌드 오류 없음)
- 자기 자신 드롭다운 비활성화 조건 검증
- `organizationName` 미존재 시 뱃지 미표시 확인

Closes #73