### PR TITLE
feat(#75): 조직 생성 및 전환 UI

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -91,6 +91,28 @@
 
 ---
 
+## ADR-009: 조직 전환 UI
+
+**결정:** 헤더 조직명 뱃지를 `OrgSwitcher` 드롭다운 컴포넌트로 교체
+
+**구현 위치:** `src/components/ui/OrgSwitcher.tsx`
+
+**상태 관리:**
+- `useAuthStore`에 `switchOrganization(id, name)` 액션 추가
+- 드롭다운 열 때마다 `GET /users/me/organizations` 호출 (매번 최신 목록 보장)
+- 조직 선택 시 store의 `user.organizationId`, `user.organizationName`만 업데이트 → 이후 API 호출(계약 목록 등)에 자동 반영
+
+**새 조직 생성 모달:**
+- 같은 파일 내 `NewOrgModal` 컴포넌트 (코드 응집도 유지)
+- 생성 성공 후 새 조직으로 즉시 전환 + Toast "Organization created"
+
+**API 추가:**
+- `listMyOrganizations()` → `GET /users/me/organizations`
+- `createOrganization(name)` → `POST /organizations`
+- 응답 타입: `OrganizationSummary { id, name, plan, role }`
+
+---
+
 ## 라이브러리 선택 요약
 
 | 용도 | 라이브러리 |

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
+import { OrgSwitcher } from "@/components/ui/OrgSwitcher";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -63,11 +64,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         </nav>
 
         <div className="flex items-center gap-3">
-          {user?.organizationName && (
-            <span className="hidden sm:inline-flex items-center rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-600 border border-zinc-200">
-              {user.organizationName}
-            </span>
-          )}
+          <OrgSwitcher />
           {user && (
             <span className="text-sm text-zinc-500 hidden sm:inline">
               {user.fullName}

--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useAuthStore } from "@/lib/auth";
+import { api } from "@/lib/api";
+import { useToast } from "@/components/ui/Toast";
+import type { OrganizationSummary } from "@/types";
+
+// ─────────────────────────────────────────────
+// New Org Modal
+// ─────────────────────────────────────────────
+
+interface NewOrgModalProps {
+  onClose: () => void;
+  onCreated: (org: OrganizationSummary) => void;
+}
+
+function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
+  const [name, setName] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    setStatus("loading");
+    setErrorMsg(null);
+    try {
+      const org = await api.createOrganization(trimmed);
+      onCreated({ id: org.id, name: org.name, plan: org.plan, role: "admin" });
+    } catch (err: unknown) {
+      setStatus("error");
+      setErrorMsg(err instanceof Error ? err.message : "Failed to create organization");
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-base font-semibold text-zinc-900">
+          New Organization
+        </h2>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="org-name" className="text-sm font-medium text-zinc-700">
+              Organization name
+            </label>
+            <input
+              id="org-name"
+              ref={inputRef}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Acme Corp"
+              maxLength={100}
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-400 disabled:opacity-50"
+              disabled={status === "loading"}
+            />
+            {errorMsg && (
+              <p className="text-xs text-red-600">{errorMsg}</p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={status === "loading" || name.trim().length === 0}
+              className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+            >
+              {status === "loading" ? "Creating..." : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// OrgSwitcher dropdown
+// ─────────────────────────────────────────────
+
+export function OrgSwitcher() {
+  const { user, switchOrganization } = useAuthStore();
+  const { toast } = useToast();
+
+  const [open, setOpen] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [orgs, setOrgs] = useState<OrganizationSummary[]>([]);
+  const [loadStatus, setLoadStatus] = useState<"idle" | "loading" | "error">("idle");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  const loadOrgs = useCallback(async () => {
+    setLoadStatus("loading");
+    try {
+      const data = await api.listMyOrganizations();
+      setOrgs(data);
+      setLoadStatus("idle");
+    } catch {
+      setLoadStatus("error");
+    }
+  }, []);
+
+  function handleOpen() {
+    setOpen((prev) => {
+      if (!prev) loadOrgs();
+      return !prev;
+    });
+  }
+
+  function handleSelect(org: OrganizationSummary) {
+    switchOrganization(org.id, org.name);
+    setOpen(false);
+  }
+
+  function handleCreated(org: OrganizationSummary) {
+    setOrgs((prev) => [...prev, org]);
+    switchOrganization(org.id, org.name);
+    setShowModal(false);
+    setOpen(false);
+    toast("success", "Organization created");
+  }
+
+  const currentOrgName = user?.organizationName;
+  const currentOrgId = user?.organizationId;
+
+  if (!currentOrgName) return null;
+
+  return (
+    <>
+      <div ref={dropdownRef} className="relative hidden sm:block">
+        <button
+          onClick={handleOpen}
+          className="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-600 border border-zinc-200 hover:bg-zinc-200 transition-colors"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+        >
+          {currentOrgName}
+          <svg
+            className={`h-3 w-3 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {open && (
+          <div
+            role="listbox"
+            className="absolute left-0 top-full mt-1.5 w-56 rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
+          >
+            {loadStatus === "loading" && (
+              <p className="px-3 py-2 text-xs text-zinc-400">Loading...</p>
+            )}
+            {loadStatus === "error" && (
+              <p className="px-3 py-2 text-xs text-red-500">Failed to load organizations</p>
+            )}
+            {loadStatus === "idle" && orgs.length === 0 && (
+              <p className="px-3 py-2 text-xs text-zinc-400">No organizations found</p>
+            )}
+            {loadStatus === "idle" && orgs.map((org) => {
+              const isActive = org.id === currentOrgId;
+              return (
+                <button
+                  key={org.id}
+                  role="option"
+                  aria-selected={isActive}
+                  onClick={() => handleSelect(org)}
+                  className="flex w-full items-center justify-between px-3 py-2 text-sm text-zinc-700 hover:bg-zinc-50"
+                >
+                  <span className="truncate">{org.name}</span>
+                  {isActive && (
+                    <svg className="ml-2 h-4 w-4 flex-shrink-0 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  )}
+                </button>
+              );
+            })}
+
+            <div className="mt-1 border-t border-zinc-100 pt-1">
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  setShowModal(true);
+                }}
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-600 hover:bg-zinc-50"
+              >
+                <svg className="h-4 w-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                New organization
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showModal && (
+        <NewOrgModal
+          onClose={() => setShowModal(false)}
+          onCreated={handleCreated}
+        />
+      )}
+    </>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   SignupResponse,
   User,
   Organization,
+  OrganizationSummary,
   MemberInfo,
   MembersResponse,
   Contract,
@@ -284,6 +285,17 @@ async function updateMemberRole(
   );
 }
 
+async function listMyOrganizations(): Promise<OrganizationSummary[]> {
+  return request<OrganizationSummary[]>("/users/me/organizations");
+}
+
+async function createOrganization(name: string): Promise<Organization> {
+  return request<Organization>("/organizations", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+}
+
 // ─────────────────────────────────────────────
 // Contract endpoints
 // ─────────────────────────────────────────────
@@ -519,6 +531,8 @@ export const api = {
   inviteMember,
   removeMember,
   updateMemberRole,
+  listMyOrganizations,
+  createOrganization,
 
   // Contracts
   listContracts,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,7 @@ interface AuthState {
   setAuth: (token: string, user: User) => void;
   clearAuth: () => void;
   setAccessToken: (token: string) => void;
+  switchOrganization: (organizationId: string, organizationName: string) => void;
 }
 
 /**
@@ -20,4 +21,10 @@ export const useAuthStore = create<AuthState>()((set) => ({
   setAuth: (token, user) => set({ accessToken: token, user }),
   clearAuth: () => set({ accessToken: null, user: null }),
   setAccessToken: (token) => set({ accessToken: token }),
+  switchOrganization: (organizationId, organizationName) =>
+    set((state) => ({
+      user: state.user
+        ? { ...state.user, organizationId, organizationName }
+        : null,
+    })),
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,15 @@ export interface SignupResponse {
 // ─────────────────────────────────────────────
 // Organization
 // ─────────────────────────────────────────────
+
+/** Summary of an organization returned by GET /users/me/organizations */
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+  plan: string;
+  role: string;
+}
+
 export interface Organization {
   id: string;
   name: string;


### PR DESCRIPTION
## 변경사항

- `OrganizationSummary` 타입 추가 (`src/types/index.ts`)
- `listMyOrganizations()` — `GET /users/me/organizations` API 함수 추가
- `createOrganization(name)` — `POST /organizations` API 함수 추가
- `useAuthStore`에 `switchOrganization(id, name)` 액션 추가 — store의 `user.organizationId`, `user.organizationName` 업데이트
- `OrgSwitcher` 드롭다운 컴포넌트 구현 (`src/components/ui/OrgSwitcher.tsx`)
  - 클릭 시 `GET /users/me/organizations` 호출로 최신 조직 목록 표시
  - 현재 선택 조직에 체크마크
  - 목록 하단 "New organization" 버튼
  - 조직 선택 시 페이지 새로고침 없이 store 업데이트
- `NewOrgModal` 구현 (OrgSwitcher 내)
  - 조직 이름 입력 → `POST /organizations` → 새 조직으로 자동 전환 → Toast "Organization created"
- 헤더의 정적 조직명 뱃지를 `OrgSwitcher` 컴포넌트로 교체 (`src/app/(app)/layout.tsx`)
- ADR-009 기록 (`DECISIONS.md`)

## QA 결과

- `npm run build` 통과 (TypeScript strict 모드 포함)
- `any` 타입 미사용
- 로딩/에러/성공 3가지 상태 모두 처리

Closes #75