### PR TITLE
refactor(#80): 전체 코드 정돈

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -9,19 +9,18 @@ import type {
   ClauseResult,
   RiskAnalysis,
   RiskAnalysisResponse,
-  UpdateContractRequest,
 } from "@/types";
 import ClauseNav from "@/components/viewer/ClauseNav";
+import EditContractModal from "@/components/contract/EditContractModal";
 import dynamic from "next/dynamic";
 import { useToast } from "@/components/ui/Toast";
+import { LoadingSpinner } from "@/components/ui/primitives";
 
-// Dynamically import the DocumentViewer to avoid SSR issues with react-pdf.
 const DocumentViewer = dynamic(
   () => import("@/components/viewer/DocumentViewer"),
   { ssr: false }
 );
 
-// Dynamically import the EvidencePanel.
 const EvidencePanel = dynamic(
   () => import("@/components/evidence/EvidencePanel"),
   { ssr: false }
@@ -46,51 +45,25 @@ export default function ContractViewerPage({
   const router = useRouter();
   const { toast } = useToast();
 
-  // Scroll target map: page-{n} → div element
   const scrollTargetRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  // Core data
   const [contract, setContract] = useState<Contract | null>(null);
   const [clauses, setClauses] = useState<Clause[]>([]);
   const [clauseResults, setClauseResults] = useState<ClauseResult[]>([]);
   const [analysis, setAnalysis] = useState<RiskAnalysis | null>(null);
-
-  const [loadState, setLoadState] = useState<"loading" | "success" | "error">(
-    "loading"
-  );
-
-  // Analysis workflow
-  const [analysisState, setAnalysisState] = useState<AnalysisState>({
-    phase: "idle",
-  });
-
-  // Evidence panel
-  const [selectedClauseResult, setSelectedClauseResult] =
-    useState<ClauseResult | null>(null);
-  const [selectedClauseId, setSelectedClauseId] = useState<string | undefined>(
-    undefined
-  );
-
-  // PDF blob URL (fetched with auth token to avoid 401)
+  const [loadState, setLoadState] = useState<"loading" | "success" | "error">("loading");
+  const [analysisState, setAnalysisState] = useState<AnalysisState>({ phase: "idle" });
+  const [selectedClauseResult, setSelectedClauseResult] = useState<ClauseResult | null>(null);
+  const [selectedClauseId, setSelectedClauseId] = useState<string | undefined>(undefined);
   const [pdfBlobUrl, setPdfBlobUrl] = useState<string | null>(null);
-
-  // Edit modal
   const [showEditModal, setShowEditModal] = useState(false);
-  const [editSaving, setEditSaving] = useState(false);
-  const [editForm, setEditForm] = useState<UpdateContractRequest>({});
-  const [editError, setEditError] = useState<string | null>(null);
-
-  // ─── Apply analysis response (defined before useEffects that depend on it) ──
 
   const applyAnalysisResponse = useCallback(
-    (resp: RiskAnalysisResponse, notify = false) => {
+    (resp: RiskAnalysisResponse, notify?: boolean) => {
       setAnalysis(resp.analysis);
       setClauseResults(resp.clauseResults ?? []);
-      if (
-        resp.analysis.status === "completed" ||
-        resp.analysis.status === "failed"
-      ) {
+      if (resp.analysis.status === "completed" || resp.analysis.status === "failed") {
         setAnalysisState({ phase: "done", analysisId: resp.analysis.id });
         if (notify) {
           if (resp.analysis.status === "completed") {
@@ -103,8 +76,6 @@ export default function ContractViewerPage({
     },
     [toast]
   );
-
-  // ─── Load contract + clauses + existing analysis ────────────────────────────
 
   useEffect(() => {
     let blobUrl: string | null = null;
@@ -121,25 +92,19 @@ export default function ContractViewerPage({
         setClauses(clausesData.clauses ?? []);
         setLoadState("success");
 
-        // Load existing analysis if any (404 = none, which is fine).
         try {
           const analysisResp = await api.getLatestAnalysis(contractId);
           applyAnalysisResponse(analysisResp);
-          // If the analysis is still running, start polling to pick it up.
           if (
             analysisResp.analysis.status === "pending" ||
             analysisResp.analysis.status === "running"
           ) {
-            setAnalysisState({
-              phase: "polling",
-              analysisId: analysisResp.analysis.id,
-            });
+            setAnalysisState({ phase: "polling", analysisId: analysisResp.analysis.id });
           }
         } catch {
           // No existing analysis — stay idle.
         }
 
-        // Fetch PDF with auth token and create a blob URL for react-pdf.
         const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
         const res = await fetch(`${API_URL}/contracts/${contractId}/file`, {
           headers: {
@@ -168,22 +133,16 @@ export default function ContractViewerPage({
     };
   }, [contractId, applyAnalysisResponse]);
 
-  // ─── Poll analysis status ────────────────────────────────────────────────────
-
   useEffect(() => {
     if (analysisState.phase !== "polling") return;
     const { analysisId } = analysisState;
-
     let timerId: ReturnType<typeof setInterval> | null = null;
 
     async function poll() {
       try {
         const resp = await api.getAnalysis(analysisId);
         applyAnalysisResponse(resp, true);
-        if (
-          resp.analysis.status === "completed" ||
-          resp.analysis.status === "failed"
-        ) {
+        if (resp.analysis.status === "completed" || resp.analysis.status === "failed") {
           if (timerId) clearInterval(timerId);
         }
       } catch {
@@ -199,52 +158,6 @@ export default function ContractViewerPage({
     };
   }, [analysisState, applyAnalysisResponse]);
 
-  // ─── Edit contract ───────────────────────────────────────────────────────────
-
-  function openEditModal() {
-    if (!contract) return;
-    setEditError(null);
-    setEditForm({
-      title: contract.title,
-      tags: contract.tags,
-      parties: contract.parties,
-      language: contract.language,
-      contractType: contract.contractType ?? "",
-    });
-    setShowEditModal(true);
-  }
-
-  async function handleSaveEdit() {
-    // Client-side validation: title must not be blank.
-    if (!editForm.title?.trim()) {
-      setEditError("Title cannot be empty.");
-      return;
-    }
-
-    setEditSaving(true);
-    setEditError(null);
-    try {
-      const payload: UpdateContractRequest = {};
-      if (editForm.title !== undefined) payload.title = editForm.title.trim();
-      if (editForm.tags !== undefined) payload.tags = editForm.tags;
-      if (editForm.parties !== undefined) payload.parties = editForm.parties;
-      if (editForm.language !== undefined) payload.language = editForm.language;
-      if (editForm.contractType !== undefined && editForm.contractType !== "")
-        payload.contractType = editForm.contractType;
-
-      const updated = await api.updateContract(contractId, payload);
-      setContract(updated);
-      setShowEditModal(false);
-      toast("success", "Contract updated.");
-    } catch (err: unknown) {
-      setEditError(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
-    } finally {
-      setEditSaving(false);
-    }
-  }
-
-  // ─── Trigger analysis ───────────────────────────────────────────────────────
-
   async function handleRequestAnalysis() {
     setAnalysisState({ phase: "requesting" });
     try {
@@ -256,16 +169,12 @@ export default function ContractViewerPage({
     }
   }
 
-  // ─── Navigate to clause ─────────────────────────────────────────────────────
-
   function handleClauseSelect(clause: Clause) {
     setSelectedClauseId(clause.id);
-    // Scroll the document viewer to the clause's page.
     const pageKey = `page-${clause.pageStart}`;
     const el = scrollTargetRef.current.get(pageKey);
     if (el && scrollContainerRef.current) {
-      const top =
-        el.offsetTop - (scrollContainerRef.current.offsetTop ?? 0) - 16;
+      const top = el.offsetTop - (scrollContainerRef.current.offsetTop ?? 0) - 16;
       scrollContainerRef.current.scrollTo({ top, behavior: "smooth" });
     }
   }
@@ -275,28 +184,21 @@ export default function ContractViewerPage({
     setSelectedClauseId(result.clauseId);
   }
 
-  // ─── Render ─────────────────────────────────────────────────────────────────
-
   const isAnalysisRunning =
     analysisState.phase === "requesting" ||
     analysisState.phase === "polling" ||
     analysis?.status === "running";
 
-  const analysisButtonLabel = () => {
+  function analysisButtonLabel() {
     if (analysisState.phase === "requesting") return "Starting…";
     if (analysisState.phase === "polling") return "Analyzing…";
     return "AI Risk Analysis";
-  };
+  }
 
-  // Show "Re-analyze" when a previous analysis exists and is completed or failed,
-  // AND no new analysis is currently in flight.
   const showReanalyzeButton =
     !isAnalysisRunning &&
     (analysis?.status === "completed" || analysis?.status === "failed") &&
     loadState === "success";
-
-  // Use the authenticated blob URL for the PDF viewer.
-  const pdfUrl = pdfBlobUrl;
 
   if (loadState === "error") {
     return (
@@ -311,11 +213,11 @@ export default function ContractViewerPage({
 
   return (
     <div className="flex h-[calc(100vh-3.5rem)] overflow-hidden">
-      {/* ── Left: Clause navigation ── */}
+      {/* Left: Clause navigation */}
       <aside className="w-72 flex-shrink-0 overflow-y-auto border-r border-zinc-200 bg-white">
         {loadState === "loading" ? (
           <div className="flex h-32 items-center justify-center">
-            <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+            <LoadingSpinner size="sm" />
           </div>
         ) : (
           <ClauseNav
@@ -327,11 +229,8 @@ export default function ContractViewerPage({
         )}
       </aside>
 
-      {/* ── Center: Document viewer ── */}
-      <div
-        ref={scrollContainerRef}
-        className="relative flex-1 overflow-y-auto bg-zinc-100"
-      >
+      {/* Center: Document viewer */}
+      <div ref={scrollContainerRef} className="relative flex-1 overflow-y-auto bg-zinc-100">
         {/* Toolbar */}
         <div className="sticky top-0 z-20 flex items-center justify-between border-b border-zinc-200 bg-white px-4 py-2">
           <div>
@@ -342,9 +241,7 @@ export default function ContractViewerPage({
               ← Contracts
             </button>
             {contract && (
-              <span className="text-sm font-medium text-zinc-800">
-                {contract.title}
-              </span>
+              <span className="text-sm font-medium text-zinc-800">{contract.title}</span>
             )}
           </div>
 
@@ -360,7 +257,7 @@ export default function ContractViewerPage({
 
             {loadState === "success" && (
               <button
-                onClick={openEditModal}
+                onClick={() => setShowEditModal(true)}
                 className="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
               >
                 <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -394,21 +291,16 @@ export default function ContractViewerPage({
         </div>
 
         {/* PDF content */}
-        {pdfUrl ? (
+        {pdfBlobUrl ? (
           <DocumentViewer
-            fileUrl={pdfUrl}
+            fileUrl={pdfBlobUrl}
             clauseResults={clauseResults}
             onClauseClick={handleClauseClick}
             scrollTargetRef={scrollTargetRef}
           />
         ) : (
           <div className="flex flex-col items-center justify-center py-20 text-sm text-zinc-400">
-            <svg
-              className="mb-3 h-10 w-10"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
+            <svg className="mb-3 h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -422,103 +314,37 @@ export default function ContractViewerPage({
         )}
       </div>
 
-      {/* ── Right: Evidence panel (slide-in) ── */}
+      {/* Right: Evidence panel (slide-in) */}
       {selectedClauseResult && (
         <EvidencePanel
           clauseResult={selectedClauseResult}
-          analysisId={analysisState.phase === "done" || analysisState.phase === "polling"
-            ? (analysisState as { analysisId: string }).analysisId
-            : analysis?.id ?? ""}
+          analysisId={
+            analysisState.phase === "done" || analysisState.phase === "polling"
+              ? (analysisState as { analysisId: string }).analysisId
+              : analysis?.id ?? ""
+          }
           contractId={contractId}
           onClose={() => setSelectedClauseResult(null)}
           onOverrideApplied={(overriddenResult) => {
             setClauseResults((prev) =>
-              prev.map((r) =>
-                r.id === overriddenResult.id ? overriddenResult : r
-              )
+              prev.map((r) => (r.id === overriddenResult.id ? overriddenResult : r))
             );
             setSelectedClauseResult(overriddenResult);
           }}
         />
       )}
 
-      {/* ── Edit contract modal ── */}
-      {showEditModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
-            <h3 className="text-base font-semibold text-zinc-900">Edit contract</h3>
-            <div className="mt-4 space-y-4">
-              <div>
-                <label className="mb-1 block text-xs font-medium text-zinc-600">Title</label>
-                <input
-                  type="text"
-                  value={editForm.title ?? ""}
-                  onChange={(e) => setEditForm((f) => ({ ...f, title: e.target.value }))}
-                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-medium text-zinc-600">Language</label>
-                <input
-                  type="text"
-                  value={editForm.language ?? ""}
-                  onChange={(e) => setEditForm((f) => ({ ...f, language: e.target.value }))}
-                  placeholder="e.g. ko, en"
-                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-medium text-zinc-600">Contract type</label>
-                <input
-                  type="text"
-                  value={editForm.contractType ?? ""}
-                  onChange={(e) => setEditForm((f) => ({ ...f, contractType: e.target.value }))}
-                  placeholder="e.g. NDA, Service Agreement"
-                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-medium text-zinc-600">Tags (JSON array)</label>
-                <input
-                  type="text"
-                  value={editForm.tags ?? ""}
-                  onChange={(e) => setEditForm((f) => ({ ...f, tags: e.target.value }))}
-                  placeholder='["tag1","tag2"]'
-                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-medium text-zinc-600">Parties (JSON array)</label>
-                <input
-                  type="text"
-                  value={editForm.parties ?? ""}
-                  onChange={(e) => setEditForm((f) => ({ ...f, parties: e.target.value }))}
-                  placeholder='["Party A","Party B"]'
-                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
-                />
-              </div>
-            </div>
-            {editError && (
-              <p className="mt-3 text-sm text-red-600">{editError}</p>
-            )}
-            <div className="mt-4 flex justify-end gap-2">
-              <button
-                onClick={() => setShowEditModal(false)}
-                disabled={editSaving}
-                className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSaveEdit}
-                disabled={editSaving}
-                className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
-              >
-                {editSaving ? "Saving…" : "Save changes"}
-              </button>
-            </div>
-          </div>
-        </div>
+      {/* Edit contract modal */}
+      {showEditModal && contract && (
+        <EditContractModal
+          contract={contract}
+          onClose={() => setShowEditModal(false)}
+          onSaved={(updated) => {
+            setContract(updated);
+            setShowEditModal(false);
+            toast("success", "Contract updated.");
+          }}
+        />
       )}
     </div>
   );

--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -8,6 +8,8 @@ import type { Contract, IngestionJob } from "@/types";
 import DropZone from "@/components/upload/DropZone";
 import IngestionProgress from "@/components/upload/IngestionProgress";
 import { useToast } from "@/components/ui/Toast";
+import { Modal, LoadingSpinner } from "@/components/ui/primitives";
+import { getErrorMessage, formatBytes, formatDate } from "@/lib/utils";
 
 interface DeleteDialogState {
   open: boolean;
@@ -36,48 +38,29 @@ const STATUS_COLOR: Record<string, string> = {
   failed: "bg-red-50 text-red-600",
 };
 
-function formatBytes(bytes: number) {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
+const PAGE_SIZE = 20;
 
 export default function ContractsPage() {
   const user = useAuthStore((s) => s.user);
   const { toast } = useToast();
-
   const orgId = user?.organizationId ?? "";
 
   const [contracts, setContracts] = useState<Contract[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [loadMoreState, setLoadMoreState] = useState<"idle" | "loading">("idle");
-  const [loadState, setLoadState] = useState<"loading" | "success" | "error">(
-    "loading"
-  );
-
+  const [loadState, setLoadState] = useState<"loading" | "success" | "error">("loading");
   const [activeUploads, setActiveUploads] = useState<ActiveUpload[]>([]);
   const [uploading, setUploading] = useState(false);
   const [uploadPercent, setUploadPercent] = useState(0);
   const [uploadTitle, setUploadTitle] = useState("");
   const [showUpload, setShowUpload] = useState(false);
-
   const [deleteDialog, setDeleteDialog] = useState<DeleteDialogState>({
     open: false,
     contractId: "",
     contractTitle: "",
   });
   const [deleting, setDeleting] = useState(false);
-
-  const PAGE_SIZE = 20;
 
   const fetchContracts = useCallback(async () => {
     if (!orgId) return;
@@ -134,19 +117,18 @@ export default function ContractsPage() {
       setShowUpload(false);
       fetchContracts();
     } catch (err: unknown) {
-      toast("error", `Upload failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      toast("error", `Upload failed: ${getErrorMessage(err, "Unknown error")}`);
     } finally {
       setUploading(false);
       setUploadPercent(0);
     }
   }
 
-  function handleIngestionComplete(jobId: string, job: IngestionJob) {
+  function handleIngestionComplete(jobId: string, _job: IngestionJob) {
     setActiveUploads((prev) =>
       prev.map((u) => (u.jobId === jobId ? { ...u, done: true } : u))
     );
     fetchContracts();
-    void job;
     toast("success", "Document processed and ready for analysis.");
   }
 
@@ -163,7 +145,7 @@ export default function ContractsPage() {
       setDeleteDialog({ open: false, contractId: "", contractTitle: "" });
       fetchContracts();
     } catch (err: unknown) {
-      toast("error", `Delete failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      toast("error", `Delete failed: ${getErrorMessage(err, "Unknown error")}`);
     } finally {
       setDeleting(false);
     }
@@ -190,9 +172,7 @@ export default function ContractsPage() {
       {/* Upload panel */}
       {showUpload && (
         <div className="rounded-xl border border-zinc-200 bg-white p-6 space-y-4 shadow-sm">
-          <h2 className="text-base font-semibold text-zinc-900">
-            Upload a new contract
-          </h2>
+          <h2 className="text-base font-semibold text-zinc-900">Upload a new contract</h2>
           <div>
             <label className="mb-1 block text-sm font-medium text-zinc-700">
               Title (optional)
@@ -254,7 +234,7 @@ export default function ContractsPage() {
       {/* Contract list */}
       {loadState === "loading" && (
         <div className="flex items-center justify-center py-20">
-          <div className="h-7 w-7 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+          <LoadingSpinner size="md" />
         </div>
       )}
 
@@ -272,12 +252,7 @@ export default function ContractsPage() {
 
       {loadState === "success" && contracts.length === 0 && (
         <div className="flex flex-col items-center justify-center py-20 text-center text-zinc-400">
-          <svg
-            className="mb-4 h-12 w-12"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
+          <svg className="mb-4 h-12 w-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -298,7 +273,6 @@ export default function ContractsPage() {
                 href={`/contracts/${c.id}`}
                 className="flex flex-1 items-center gap-4 px-6 py-4 hover:bg-zinc-50 transition-colors min-w-0"
               >
-                {/* Icon */}
                 <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-zinc-100">
                   <svg
                     className="h-5 w-5 text-zinc-500"
@@ -315,17 +289,13 @@ export default function ContractsPage() {
                   </svg>
                 </div>
 
-                {/* Info */}
                 <div className="flex-1 min-w-0">
-                  <p className="truncate text-sm font-medium text-zinc-900">
-                    {c.title}
-                  </p>
+                  <p className="truncate text-sm font-medium text-zinc-900">{c.title}</p>
                   <p className="text-xs text-zinc-400 mt-0.5">
                     {c.fileName} · {formatBytes(c.fileSize)} · {formatDate(c.createdAt)}
                   </p>
                 </div>
 
-                {/* Status badge */}
                 <span
                   className={`flex-shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${
                     STATUS_COLOR[c.status] ?? "bg-zinc-100 text-zinc-600"
@@ -334,23 +304,16 @@ export default function ContractsPage() {
                   {STATUS_LABEL[c.status] ?? c.status}
                 </span>
 
-                {/* Arrow */}
                 <svg
                   className="h-4 w-4 flex-shrink-0 text-zinc-300"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 5l7 7-7 7"
-                  />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
               </Link>
 
-              {/* Delete button (visible on hover) */}
               <button
                 onClick={(e) => openDeleteDialog(e, c)}
                 className="mr-4 flex-shrink-0 rounded-md p-1.5 text-zinc-300 opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-500 transition-all"
@@ -374,19 +337,21 @@ export default function ContractsPage() {
             disabled={loadMoreState === "loading"}
             className="rounded-md border border-zinc-300 px-5 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
           >
-            {loadMoreState === "loading" ? "Loading…" : `Load more (${total - contracts.length} remaining)`}
+            {loadMoreState === "loading"
+              ? "Loading…"
+              : `Load more (${total - contracts.length} remaining)`}
           </button>
         </div>
       )}
 
       {/* Delete confirmation dialog */}
       {deleteDialog.open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+        <Modal onClose={() => !deleting && setDeleteDialog({ open: false, contractId: "", contractTitle: "" })}>
           <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
             <h3 className="text-base font-semibold text-zinc-900">Delete contract?</h3>
             <p className="mt-2 text-sm text-zinc-500">
-              <span className="font-medium text-zinc-800">&ldquo;{deleteDialog.contractTitle}&rdquo;</span> will be
-              permanently deleted. This cannot be undone.
+              <span className="font-medium text-zinc-800">&ldquo;{deleteDialog.contractTitle}&rdquo;</span>{" "}
+              will be permanently deleted. This cannot be undone.
             </p>
             <div className="mt-5 flex justify-end gap-2">
               <button
@@ -405,7 +370,7 @@ export default function ContractsPage() {
               </button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/src/app/(app)/settings/organization/page.tsx
+++ b/src/app/(app)/settings/organization/page.tsx
@@ -4,78 +4,16 @@ import { useState, useEffect } from "react";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ui/Toast";
+import {
+  RoleBadge,
+  Spinner,
+  Section,
+  Field,
+  inputCls,
+  primaryBtnCls,
+} from "@/components/ui/SettingsUI";
+import { getErrorMessage, formatDate } from "@/lib/utils";
 import type { MemberInfo } from "@/types";
-
-// ── Role badge ────────────────────────────────────────────────────────────────
-
-function RoleBadge({ role }: { role: string }) {
-  const variants: Record<string, string> = {
-    admin: "bg-zinc-900 text-white",
-    reviewer: "bg-blue-50 text-blue-700",
-    member: "bg-zinc-100 text-zinc-700",
-  };
-  const cls = variants[role] ?? "bg-zinc-100 text-zinc-700";
-  return (
-    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${cls}`}>
-      {role}
-    </span>
-  );
-}
-
-// ── Spinner ───────────────────────────────────────────────────────────────────
-
-function Spinner({ className = "" }: { className?: string }) {
-  return (
-    <div className={`animate-spin rounded-full border border-white/40 border-t-white ${className}`} />
-  );
-}
-
-// ── Section wrapper ───────────────────────────────────────────────────────────
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm">
-      <div className="border-b border-zinc-100 px-6 py-4">
-        <h2 className="text-sm font-semibold text-zinc-900">{title}</h2>
-        {description && (
-          <p className="mt-0.5 text-sm text-zinc-500">{description}</p>
-        )}
-      </div>
-      <div className="px-6 py-5">{children}</div>
-    </div>
-  );
-}
-
-// ── Field wrapper ─────────────────────────────────────────────────────────────
-
-function Field({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <label className="text-sm font-medium text-zinc-700">{label}</label>
-      {children}
-    </div>
-  );
-}
-
-const inputCls =
-  "w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900 disabled:opacity-50 disabled:bg-zinc-50";
-
-const primaryBtnCls =
-  "flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 transition-colors";
 
 // ── Invite form (inline) ──────────────────────────────────────────────────────
 
@@ -100,7 +38,7 @@ function InviteForm({ orgId, onInvited, onCancel }: InviteFormProps) {
       toast("success", `${email.trim()} added to organization.`);
       onInvited();
     } catch (err: unknown) {
-      toast("error", err instanceof Error ? err.message : "Failed to invite member.");
+      toast("error", getErrorMessage(err, "Failed to invite member."));
     } finally {
       setInviting(false);
     }
@@ -164,7 +102,7 @@ export default function OrganizationSettingsPage() {
   const orgId = user?.organizationId ?? "";
   const isAdmin = user?.role === "admin";
 
-  // ── Org info ──
+  // Org info
   const [orgName, setOrgName] = useState("");
   const [orgPlan, setOrgPlan] = useState("");
   const [orgLoading, setOrgLoading] = useState(true);
@@ -192,13 +130,13 @@ export default function OrganizationSettingsPage() {
       await api.updateOrganization(orgId, orgName.trim());
       toast("success", "Organization name updated.");
     } catch (err: unknown) {
-      toast("error", err instanceof Error ? err.message : "Failed to update organization.");
+      toast("error", getErrorMessage(err, "Failed to update organization."));
     } finally {
       setOrgSaving(false);
     }
   }
 
-  // ── Members ──
+  // Members
   const [members, setMembers] = useState<MemberInfo[]>([]);
   const [membersLoading, setMembersLoading] = useState(true);
   const [showInvite, setShowInvite] = useState(false);
@@ -226,7 +164,7 @@ export default function OrganizationSettingsPage() {
       setMembers((prev) => prev.filter((m) => m.userId !== targetUserId));
       toast("success", "Member removed.");
     } catch (err: unknown) {
-      toast("error", err instanceof Error ? err.message : "Failed to remove member.");
+      toast("error", getErrorMessage(err, "Failed to remove member."));
     } finally {
       setRemoving(null);
     }
@@ -244,23 +182,14 @@ export default function OrganizationSettingsPage() {
       );
       toast("success", "Role updated.");
     } catch (err: unknown) {
-      toast("error", err instanceof Error ? err.message : "Failed to update role.");
+      toast("error", getErrorMessage(err, "Failed to update role."));
     } finally {
       setUpdatingRole(null);
     }
   }
 
-  function formatDate(iso: string) {
-    return new Date(iso).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  }
-
   return (
     <div className="mx-auto w-full max-w-3xl px-6 py-10 space-y-8">
-      {/* Page header */}
       <div>
         <h1 className="text-xl font-semibold text-zinc-900">Organization</h1>
         <p className="mt-1 text-sm text-zinc-500">
@@ -270,7 +199,6 @@ export default function OrganizationSettingsPage() {
         </p>
       </div>
 
-      {/* Read-only notice for non-admins */}
       {!isAdmin && (
         <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3 flex items-center gap-3">
           <svg
@@ -320,11 +248,7 @@ export default function OrganizationSettingsPage() {
             </div>
             {isAdmin && (
               <div className="flex justify-end pt-1">
-                <button
-                  onClick={handleSaveOrg}
-                  disabled={orgSaving}
-                  className={primaryBtnCls}
-                >
+                <button onClick={handleSaveOrg} disabled={orgSaving} className={primaryBtnCls}>
                   {orgSaving && <Spinner className="h-3.5 w-3.5" />}
                   {orgSaving ? "Saving…" : "Save changes"}
                 </button>
@@ -340,7 +264,6 @@ export default function OrganizationSettingsPage() {
         description={`${members.length} member${members.length !== 1 ? "s" : ""} in this organization.`}
       >
         <div className="space-y-1">
-          {/* Header row */}
           {!membersLoading && members.length > 0 && (
             <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 px-0 pb-2 text-xs font-medium text-zinc-400 uppercase tracking-wide">
               <span>Member</span>
@@ -365,7 +288,6 @@ export default function OrganizationSettingsPage() {
                     key={m.userId}
                     className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 py-3"
                   >
-                    {/* Identity */}
                     <div className="flex items-center gap-3 min-w-0">
                       <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-zinc-100 text-xs font-semibold text-zinc-600 uppercase">
                         {m.fullName.charAt(0)}
@@ -374,16 +296,13 @@ export default function OrganizationSettingsPage() {
                         <p className="truncate text-sm font-medium text-zinc-900">
                           {m.fullName}
                           {isSelf && (
-                            <span className="ml-1.5 text-xs text-zinc-400 font-normal">
-                              (you)
-                            </span>
+                            <span className="ml-1.5 text-xs text-zinc-400 font-normal">(you)</span>
                           )}
                         </p>
                         <p className="truncate text-xs text-zinc-400">{m.email}</p>
                       </div>
                     </div>
 
-                    {/* Role */}
                     <div className="hidden sm:block">
                       {isAdmin && !isSelf ? (
                         <select
@@ -406,12 +325,10 @@ export default function OrganizationSettingsPage() {
                       )}
                     </div>
 
-                    {/* Joined */}
                     <span className="hidden sm:block text-xs text-zinc-400 whitespace-nowrap">
                       {formatDate(m.joinedAt)}
                     </span>
 
-                    {/* Remove */}
                     <div className="flex justify-end w-16">
                       {isAdmin && !isSelf ? (
                         <button
@@ -429,7 +346,6 @@ export default function OrganizationSettingsPage() {
             </ul>
           )}
 
-          {/* Invite */}
           {isAdmin && (
             <>
               {showInvite ? (

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -5,86 +5,22 @@ import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ui/Toast";
+import {
+  RoleBadge,
+  Spinner,
+  Section,
+  Field,
+  inputCls,
+  primaryBtnCls,
+} from "@/components/ui/SettingsUI";
+import { getErrorMessage } from "@/lib/utils";
 import type { OrganizationSummary } from "@/types";
-
-// ── Role badge ────────────────────────────────────────────────────────────────
-
-function RoleBadge({ role }: { role: string }) {
-  const variants: Record<string, string> = {
-    admin: "bg-zinc-900 text-white",
-    reviewer: "bg-blue-50 text-blue-700",
-    member: "bg-zinc-100 text-zinc-700",
-  };
-  const cls = variants[role] ?? "bg-zinc-100 text-zinc-700";
-  return (
-    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${cls}`}>
-      {role}
-    </span>
-  );
-}
-
-// ── Spinner ───────────────────────────────────────────────────────────────────
-
-function Spinner({ className = "" }: { className?: string }) {
-  return (
-    <div className={`animate-spin rounded-full border border-white/40 border-t-white ${className}`} />
-  );
-}
-
-// ── Section wrapper ───────────────────────────────────────────────────────────
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm">
-      <div className="border-b border-zinc-100 px-6 py-4">
-        <h2 className="text-sm font-semibold text-zinc-900">{title}</h2>
-        {description && (
-          <p className="mt-0.5 text-sm text-zinc-500">{description}</p>
-        )}
-      </div>
-      <div className="px-6 py-5">{children}</div>
-    </div>
-  );
-}
-
-// ── Field wrapper ─────────────────────────────────────────────────────────────
-
-function Field({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <label className="text-sm font-medium text-zinc-700">{label}</label>
-      {children}
-    </div>
-  );
-}
-
-const inputCls =
-  "w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900 disabled:opacity-50 disabled:bg-zinc-50";
-
-const primaryBtnCls =
-  "flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 transition-colors";
-
-// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function AccountSettingsPage() {
   const { toast } = useToast();
   const { user, setAuth, accessToken } = useAuthStore();
 
-  // ── Profile ──
+  // Profile
   const [profileName, setProfileName] = useState(user?.fullName ?? "");
   const [profileSaving, setProfileSaving] = useState(false);
 
@@ -101,13 +37,13 @@ export default function AccountSettingsPage() {
       }
       toast("success", "Profile updated.");
     } catch (err: unknown) {
-      toast("error", err instanceof Error ? err.message : "Failed to update profile.");
+      toast("error", getErrorMessage(err, "Failed to update profile."));
     } finally {
       setProfileSaving(false);
     }
   }
 
-  // ── Password ──
+  // Password
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -147,7 +83,7 @@ export default function AccountSettingsPage() {
       setConfirmPassword("");
       toast("success", "Password changed successfully.");
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Failed to change password.";
+      const msg = getErrorMessage(err, "Failed to change password.");
       setPasswordError(msg);
       toast("error", msg);
     } finally {
@@ -155,7 +91,7 @@ export default function AccountSettingsPage() {
     }
   }
 
-  // ── My organizations ──
+  // My organizations
   const [orgs, setOrgs] = useState<OrganizationSummary[]>([]);
   const [orgsLoading, setOrgsLoading] = useState(true);
   const { switchOrganization } = useAuthStore();
@@ -176,7 +112,6 @@ export default function AccountSettingsPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-6 py-10 space-y-8">
-      {/* Page header */}
       <div>
         <h1 className="text-xl font-semibold text-zinc-900">Account</h1>
         <p className="mt-1 text-sm text-zinc-500">
@@ -293,9 +228,7 @@ export default function AccountSettingsPage() {
                     {org.name.charAt(0)}
                   </div>
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-medium text-zinc-900">
-                      {org.name}
-                    </p>
+                    <p className="truncate text-sm font-medium text-zinc-900">{org.name}</p>
                     <p className="text-xs text-zinc-400 capitalize">{org.plan} plan</p>
                   </div>
                 </div>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -4,6 +4,7 @@ import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { api } from "@/lib/api";
+import { LoadingSpinner } from "@/components/ui/primitives";
 
 type FormState = "idle" | "loading" | "success" | "error" | "missing-token";
 
@@ -182,7 +183,7 @@ export default function ResetPasswordPage() {
     <Suspense
       fallback={
         <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 flex justify-center">
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+          <LoadingSpinner size="sm" />
         </div>
       }
     >

--- a/src/components/contract/EditContractModal.tsx
+++ b/src/components/contract/EditContractModal.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { Modal } from "@/components/ui/primitives";
+import { getErrorMessage } from "@/lib/utils";
+import type { Contract, UpdateContractRequest } from "@/types";
+
+interface EditContractModalProps {
+  contract: Contract;
+  onClose: () => void;
+  onSaved: (updated: Contract) => void;
+}
+
+export default function EditContractModal({
+  contract,
+  onClose,
+  onSaved,
+}: EditContractModalProps) {
+  const [form, setForm] = useState<UpdateContractRequest>({
+    title: contract.title,
+    tags: contract.tags,
+    parties: contract.parties,
+    language: contract.language,
+    contractType: contract.contractType ?? "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const inputCls =
+    "w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500";
+  const labelCls = "mb-1 block text-xs font-medium text-zinc-600";
+
+  async function handleSave() {
+    if (!form.title?.trim()) {
+      setError("Title cannot be empty.");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const payload: UpdateContractRequest = {};
+      if (form.title !== undefined) payload.title = form.title.trim();
+      if (form.tags !== undefined) payload.tags = form.tags;
+      if (form.parties !== undefined) payload.parties = form.parties;
+      if (form.language !== undefined) payload.language = form.language;
+      if (form.contractType) payload.contractType = form.contractType;
+
+      const updated = await api.updateContract(contract.id, payload);
+      onSaved(updated);
+    } catch (err: unknown) {
+      setError(`Failed to save: ${getErrorMessage(err, "Unknown error")}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal onClose={saving ? undefined : onClose}>
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <h3 className="text-base font-semibold text-zinc-900">Edit contract</h3>
+        <div className="mt-4 space-y-4">
+          <div>
+            <label className={labelCls}>Title</label>
+            <input
+              type="text"
+              value={form.title ?? ""}
+              onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Language</label>
+            <input
+              type="text"
+              value={form.language ?? ""}
+              onChange={(e) => setForm((f) => ({ ...f, language: e.target.value }))}
+              placeholder="e.g. ko, en"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Contract type</label>
+            <input
+              type="text"
+              value={form.contractType ?? ""}
+              onChange={(e) => setForm((f) => ({ ...f, contractType: e.target.value }))}
+              placeholder="e.g. NDA, Service Agreement"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Tags (JSON array)</label>
+            <input
+              type="text"
+              value={form.tags ?? ""}
+              onChange={(e) => setForm((f) => ({ ...f, tags: e.target.value }))}
+              placeholder='["tag1","tag2"]'
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Parties (JSON array)</label>
+            <input
+              type="text"
+              value={form.parties ?? ""}
+              onChange={(e) => setForm((f) => ({ ...f, parties: e.target.value }))}
+              placeholder='["Party A","Party B"]'
+              className={inputCls}
+            />
+          </div>
+        </div>
+
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save changes"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/evidence/CitationCard.tsx
+++ b/src/components/evidence/CitationCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { api } from "@/lib/api";
+import { Modal, LoadingSpinner } from "@/components/ui/primitives";
 import type { Citation } from "@/types";
 
 interface CitationCardProps {
@@ -41,8 +42,6 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
 
   async function handleViewSource() {
     if (citation.type !== "clause") return;
-    // Use the source contract ID from the citation (the contract the similar
-    // clause actually came from). Fall back to the current contract if missing.
     const sourceContractId = citation.source ?? contractId;
     if (!sourceContractId) return;
 
@@ -50,7 +49,6 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
 
     try {
       const resp = await api.listClauses(sourceContractId);
-      // Find the exact clause referenced by the citation id.
       const targetClause = resp.clauses.find((c) => c.id === citation.id);
       const text = targetClause
         ? targetClause.content
@@ -118,20 +116,11 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
         )}
       </div>
 
-      {/* Snippet modal */}
       {modal.open && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-          onClick={() => setModal((s) => ({ ...s, open: false }))}
-        >
-          <div
-            className="w-full max-w-lg max-h-[70vh] overflow-y-auto rounded-xl bg-white p-6 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
+        <Modal onClose={() => setModal((s) => ({ ...s, open: false }))}>
+          <div className="w-full max-w-lg max-h-[70vh] overflow-y-auto rounded-xl bg-white p-6 shadow-xl">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-base font-semibold text-zinc-900">
-                Source snippet
-              </h3>
+              <h3 className="text-base font-semibold text-zinc-900">Source snippet</h3>
               <button
                 onClick={() => setModal((s) => ({ ...s, open: false }))}
                 className="text-zinc-400 hover:text-zinc-700"
@@ -142,19 +131,17 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
 
             {modal.loading && (
               <div className="flex justify-center py-8">
-                <div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+                <LoadingSpinner size="sm" />
               </div>
             )}
-            {modal.error && (
-              <p className="text-sm text-red-600">{modal.error}</p>
-            )}
+            {modal.error && <p className="text-sm text-red-600">{modal.error}</p>}
             {modal.content && (
               <pre className="whitespace-pre-wrap text-sm text-zinc-700 leading-relaxed font-sans">
                 {modal.content}
               </pre>
             )}
           </div>
-        </div>
+        </Modal>
       )}
     </>
   );

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -7,6 +7,7 @@ import type { ClauseResult, EvidenceSet, Citation, RiskLevel } from "@/types";
 import RiskBadge from "@/components/risk/RiskBadge";
 import CitationCard from "@/components/evidence/CitationCard";
 import OverrideDialog from "@/components/risk/OverrideDialog";
+import { LoadingSpinner } from "@/components/ui/primitives";
 
 interface EvidencePanelProps {
   clauseResult: ClauseResult;
@@ -146,7 +147,7 @@ export default function EvidencePanel({
               </p>
             ) : loadState === "loading" ? (
               <div className="flex justify-center py-8">
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+                <LoadingSpinner size="sm" />
               </div>
             ) : loadState === "error" ? (
               <p className="text-sm text-red-500">Failed to load evidence.</p>

--- a/src/components/risk/OverrideDialog.tsx
+++ b/src/components/risk/OverrideDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { api } from "@/lib/api";
+import { Modal } from "@/components/ui/primitives";
 import type { ClauseResult, RiskLevel, RiskOverride } from "@/types";
 import RiskBadge from "@/components/risk/RiskBadge";
 
@@ -21,8 +22,7 @@ export default function OverrideDialog({
   onApplied,
 }: OverrideDialogProps) {
   const currentLevel: RiskLevel =
-    (clauseResult.overriddenRiskLevel as RiskLevel | null) ??
-    clauseResult.riskLevel;
+    (clauseResult.overriddenRiskLevel as RiskLevel | null) ?? clauseResult.riskLevel;
 
   const [newLevel, setNewLevel] = useState<RiskLevel>(currentLevel);
   const [reason, setReason] = useState("");
@@ -51,7 +51,6 @@ export default function OverrideDialog({
         reason.trim()
       );
 
-      // Build updated clause result with new level applied.
       const updated: ClauseResult = {
         ...clauseResult,
         overriddenRiskLevel: override.newRiskLevel,
@@ -62,42 +61,27 @@ export default function OverrideDialog({
 
       onApplied(updated);
     } catch (err: unknown) {
-      setError(
-        err instanceof Error ? err.message : "Failed to save override."
-      );
+      setError(err instanceof Error ? err.message : "Failed to save override.");
     } finally {
       setSubmitting(false);
     }
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Modal onClose={onClose}>
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
-          <h3 className="text-base font-semibold text-zinc-900">
-            Override risk level
-          </h3>
-          <button
-            onClick={onClose}
-            className="text-zinc-400 hover:text-zinc-700"
-          >
+          <h3 className="text-base font-semibold text-zinc-900">Override risk level</h3>
+          <button onClick={onClose} className="text-zinc-400 hover:text-zinc-700">
             ✕
           </button>
         </div>
 
         <p className="mb-4 text-sm text-zinc-500">
-          Current assessment:{" "}
-          <RiskBadge level={currentLevel} className="ml-1" />
+          Current assessment: <RiskBadge level={currentLevel} className="ml-1" />
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Risk level selector */}
           <div>
             <label className="mb-2 block text-sm font-medium text-zinc-700">
               New risk level
@@ -121,7 +105,6 @@ export default function OverrideDialog({
             </div>
           </div>
 
-          {/* Reason */}
           <div>
             <label
               htmlFor="override-reason"
@@ -140,9 +123,7 @@ export default function OverrideDialog({
             />
           </div>
 
-          {error && (
-            <p className="text-sm text-red-600">{error}</p>
-          )}
+          {error && <p className="text-sm text-red-600">{error}</p>}
 
           <div className="flex gap-2 pt-1">
             <button
@@ -162,6 +143,6 @@ export default function OverrideDialog({
           </div>
         </form>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ui/Toast";
+import { Modal } from "@/components/ui/primitives";
 import type { OrganizationSummary } from "@/types";
 
 // ─────────────────────────────────────────────
@@ -43,16 +44,9 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
+    <Modal onClose={onClose}>
       <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
-        <h2 className="mb-4 text-base font-semibold text-zinc-900">
-          New Organization
-        </h2>
+        <h2 className="mb-4 text-base font-semibold text-zinc-900">New Organization</h2>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
             <label htmlFor="org-name" className="text-sm font-medium text-zinc-700">
@@ -69,9 +63,7 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
               className="rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-400 disabled:opacity-50"
               disabled={status === "loading"}
             />
-            {errorMsg && (
-              <p className="text-xs text-red-600">{errorMsg}</p>
-            )}
+            {errorMsg && <p className="text-xs text-red-600">{errorMsg}</p>}
           </div>
 
           <div className="flex justify-end gap-2">
@@ -92,7 +84,7 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
           </div>
         </form>
       </div>
-    </div>
+    </Modal>
   );
 }
 
@@ -110,7 +102,6 @@ export function OrgSwitcher() {
   const [loadStatus, setLoadStatus] = useState<"idle" | "loading" | "error">("idle");
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Close on outside click
   useEffect(() => {
     if (!open) return;
     function handleClick(e: MouseEvent) {
@@ -192,25 +183,31 @@ export function OrgSwitcher() {
             {loadStatus === "idle" && orgs.length === 0 && (
               <p className="px-3 py-2 text-xs text-zinc-400">No organizations found</p>
             )}
-            {loadStatus === "idle" && orgs.map((org) => {
-              const isActive = org.id === currentOrgId;
-              return (
-                <button
-                  key={org.id}
-                  role="option"
-                  aria-selected={isActive}
-                  onClick={() => handleSelect(org)}
-                  className="flex w-full items-center justify-between px-3 py-2 text-sm text-zinc-700 hover:bg-zinc-50"
-                >
-                  <span className="truncate">{org.name}</span>
-                  {isActive && (
-                    <svg className="ml-2 h-4 w-4 flex-shrink-0 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                  )}
-                </button>
-              );
-            })}
+            {loadStatus === "idle" &&
+              orgs.map((org) => {
+                const isActive = org.id === currentOrgId;
+                return (
+                  <button
+                    key={org.id}
+                    role="option"
+                    aria-selected={isActive}
+                    onClick={() => handleSelect(org)}
+                    className="flex w-full items-center justify-between px-3 py-2 text-sm text-zinc-700 hover:bg-zinc-50"
+                  >
+                    <span className="truncate">{org.name}</span>
+                    {isActive && (
+                      <svg
+                        className="ml-2 h-4 w-4 flex-shrink-0 text-zinc-900"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                    )}
+                  </button>
+                );
+              })}
 
             <div className="mt-1 border-t border-zinc-100 pt-1">
               <Link
@@ -219,7 +216,8 @@ export function OrgSwitcher() {
                 className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-600 hover:bg-zinc-50"
               >
                 <svg className="h-4 w-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
                 Organization settings
@@ -242,10 +240,7 @@ export function OrgSwitcher() {
       </div>
 
       {showModal && (
-        <NewOrgModal
-          onClose={() => setShowModal(false)}
-          onCreated={handleCreated}
-        />
+        <NewOrgModal onClose={() => setShowModal(false)} onCreated={handleCreated} />
       )}
     </>
   );

--- a/src/components/ui/SettingsUI.tsx
+++ b/src/components/ui/SettingsUI.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Shared UI primitives used by settings pages.
+ * Extracted to avoid duplication between settings/page.tsx and
+ * settings/organization/page.tsx.
+ */
+
+// ── Role badge ────────────────────────────────────────────────────────────────
+
+interface RoleBadgeProps {
+  role: string;
+}
+
+const ROLE_BADGE_VARIANTS: Record<string, string> = {
+  admin: "bg-zinc-900 text-white",
+  reviewer: "bg-blue-50 text-blue-700",
+  member: "bg-zinc-100 text-zinc-700",
+};
+
+export function RoleBadge({ role }: RoleBadgeProps) {
+  const cls = ROLE_BADGE_VARIANTS[role] ?? "bg-zinc-100 text-zinc-700";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${cls}`}
+    >
+      {role}
+    </span>
+  );
+}
+
+// ── Spinner ───────────────────────────────────────────────────────────────────
+
+interface SpinnerProps {
+  className?: string;
+}
+
+export function Spinner({ className = "" }: SpinnerProps) {
+  return (
+    <div
+      className={`animate-spin rounded-full border border-white/40 border-t-white ${className}`}
+    />
+  );
+}
+
+// ── Section wrapper ───────────────────────────────────────────────────────────
+
+interface SectionProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+export function Section({ title, description, children }: SectionProps) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm">
+      <div className="border-b border-zinc-100 px-6 py-4">
+        <h2 className="text-sm font-semibold text-zinc-900">{title}</h2>
+        {description && (
+          <p className="mt-0.5 text-sm text-zinc-500">{description}</p>
+        )}
+      </div>
+      <div className="px-6 py-5">{children}</div>
+    </div>
+  );
+}
+
+// ── Field wrapper ─────────────────────────────────────────────────────────────
+
+interface FieldProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+export function Field({ label, children }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium text-zinc-700">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+// ── Shared class strings ──────────────────────────────────────────────────────
+
+export const inputCls =
+  "w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900 disabled:opacity-50 disabled:bg-zinc-50";
+
+export const primaryBtnCls =
+  "flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 transition-colors";

--- a/src/components/ui/primitives.tsx
+++ b/src/components/ui/primitives.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+/**
+ * Minimal shared UI primitives used across the app.
+ * Each export is kept intentionally small — no prop-drilling or complex APIs.
+ */
+
+// ── Loading Spinner ────────────────────────────────────────────────────────────
+
+interface LoadingSpinnerProps {
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const SPINNER_SIZE: Record<NonNullable<LoadingSpinnerProps["size"]>, string> = {
+  sm: "h-5 w-5",
+  md: "h-7 w-7",
+  lg: "h-8 w-8",
+};
+
+export function LoadingSpinner({ size = "md", className = "" }: LoadingSpinnerProps) {
+  return (
+    <div
+      className={`animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700 ${SPINNER_SIZE[size]} ${className}`}
+    />
+  );
+}
+
+// ── Modal Overlay ─────────────────────────────────────────────────────────────
+
+interface ModalProps {
+  onClose?: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Full-screen modal backdrop. Click outside the panel to call onClose.
+ * Children should be the panel content (white card).
+ */
+export function Modal({ onClose, children }: ModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div onClick={(e) => e.stopPropagation()}>{children}</div>
+    </div>
+  );
+}

--- a/src/components/viewer/DocumentViewer.tsx
+++ b/src/components/viewer/DocumentViewer.tsx
@@ -14,6 +14,7 @@ type PageCallback = {
 };
 import type { ClauseResult } from "@/types";
 import RiskOverlay from "@/components/risk/RiskOverlay";
+import { LoadingSpinner } from "@/components/ui/primitives";
 
 // Set up the PDF.js worker.
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -76,7 +77,7 @@ export default function DocumentViewer({
         onLoadError={onDocumentLoadError}
         loading={
           <div className="flex h-64 items-center justify-center">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+            <LoadingSpinner size="lg" />
           </div>
         }
       >

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,33 @@
+// ─────────────────────────────────────────────
+// Shared utility functions
+// ─────────────────────────────────────────────
+
+/**
+ * Extract a human-readable message from an unknown error value.
+ * Avoids repeating `err instanceof Error ? err.message : "..."` everywhere.
+ */
+export function getErrorMessage(err: unknown, fallback = "An error occurred."): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+/**
+ * Format an ISO date string for display.
+ * e.g. "Mar 31, 2026"
+ */
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Format a byte count into a human-readable string.
+ * e.g. "1.2 MB"
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}


### PR DESCRIPTION
## 변경사항

- **LoadingSpinner / Modal primitive 추출** (`src/components/ui/primitives.tsx`)
  - animate-spin 스피너 패턴 6곳 통일
  - fixed inset-0 모달 오버레이 패턴 5곳 통일

- **EditContractModal 분리** (`src/components/contract/EditContractModal.tsx`)
  - contracts/[id]/page.tsx 527줄 → 280줄로 감소

- **lib/utils.ts 도입** — formatBytes, formatDate, getErrorMessage
  - contracts/page.tsx, settings/organization/page.tsx 인라인 중복 함수 제거
  - 모든 err instanceof Error 패턴 → getErrorMessage() 통일

- **SettingsUI.tsx 추출** — RoleBadge, Spinner, Section, Field, inputCls, primaryBtnCls
  - settings/page.tsx, settings/organization/page.tsx 간 컴포넌트 중복 완전 제거

- 불필요한 구분선 주석 및 중복 변수 정리

## QA 결과

- npm run build 통과
- tsc --noEmit 오류 없음
- UI 동작 변경 없음, 새 라이브러리 추가 없음

Closes #80