### PR TITLE
feat(#82): UI 전면 polish 및 디자인 시스템 정비

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -192,7 +192,7 @@ export default function ContractViewerPage({
   function analysisButtonLabel() {
     if (analysisState.phase === "requesting") return "Starting…";
     if (analysisState.phase === "polling") return "Analyzing…";
-    return "AI Risk Analysis";
+    return "Run AI Analysis";
   }
 
   const showReanalyzeButton =
@@ -202,9 +202,17 @@ export default function ContractViewerPage({
 
   if (loadState === "error") {
     return (
-      <div className="flex h-full items-center justify-center p-8 text-sm text-red-600">
-        Failed to load contract.{" "}
-        <button onClick={() => router.back()} className="ml-1 underline">
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+          <svg className="h-5 w-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+        <p className="text-sm font-medium text-zinc-900">Failed to load contract</p>
+        <button
+          onClick={() => router.back()}
+          className="text-sm text-zinc-500 underline underline-offset-2 hover:text-zinc-700"
+        >
           Go back
         </button>
       </div>
@@ -232,37 +240,58 @@ export default function ContractViewerPage({
       {/* Center: Document viewer */}
       <div ref={scrollContainerRef} className="relative flex-1 overflow-y-auto bg-zinc-100">
         {/* Toolbar */}
-        <div className="sticky top-0 z-20 flex items-center justify-between border-b border-zinc-200 bg-white px-4 py-2">
-          <div>
+        <div className="sticky top-0 z-20 flex items-center justify-between border-b border-zinc-200 bg-white px-4 py-2.5 shadow-sm">
+          {/* Left: breadcrumb */}
+          <div className="flex min-w-0 items-center gap-2 text-sm">
             <button
               onClick={() => router.push("/contracts")}
-              className="mr-2 text-sm text-zinc-500 hover:text-zinc-900"
+              className="flex items-center gap-1 text-zinc-400 transition-colors hover:text-zinc-700"
             >
-              ← Contracts
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              <span className="text-xs">Contracts</span>
             </button>
             {contract && (
-              <span className="text-sm font-medium text-zinc-800">{contract.title}</span>
+              <>
+                <span className="text-zinc-200">/</span>
+                <span className="truncate font-medium text-zinc-800 max-w-xs">
+                  {contract.title}
+                </span>
+              </>
             )}
           </div>
 
-          <div className="flex items-center gap-2">
+          {/* Right: actions */}
+          <div className="flex flex-shrink-0 items-center gap-2">
             {analysis?.status === "completed" && (
-              <span className="text-xs text-zinc-400">
+              <span className="text-xs text-zinc-400 hidden sm:inline">
                 {clauseResults.length} clauses analyzed
               </span>
             )}
             {analysis?.status === "failed" && (
-              <span className="text-xs text-red-500">Analysis failed</span>
+              <span className="rounded-full bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-600 ring-1 ring-red-200">
+                Analysis failed
+              </span>
+            )}
+            {analysis?.status === "running" && (
+              <span className="rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
+                Analyzing…
+              </span>
             )}
 
             {loadState === "success" && (
               <button
                 onClick={() => setShowEditModal(true)}
-                className="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
               >
                 <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
                 </svg>
                 Edit
               </button>
@@ -271,18 +300,27 @@ export default function ContractViewerPage({
             {showReanalyzeButton ? (
               <button
                 onClick={handleRequestAnalysis}
-                className="flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
               >
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
                 Re-analyze
               </button>
             ) : (
               <button
                 onClick={handleRequestAnalysis}
                 disabled={isAnalysisRunning || loadState !== "success"}
-                className="flex items-center gap-1.5 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {isAnalysisRunning && (
-                  <div className="h-3 w-3 animate-spin rounded-full border border-white/40 border-t-white" />
+                {isAnalysisRunning ? (
+                  <span className="h-3 w-3 animate-spin rounded-full border border-white/30 border-t-white" />
+                ) : (
+                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                  </svg>
                 )}
                 {analysisButtonLabel()}
               </button>
@@ -299,17 +337,19 @@ export default function ContractViewerPage({
             scrollTargetRef={scrollTargetRef}
           />
         ) : (
-          <div className="flex flex-col items-center justify-center py-20 text-sm text-zinc-400">
-            <svg className="mb-3 h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              />
-            </svg>
-            <p>Document preview not available</p>
-            <p className="mt-1 text-xs">The clauses are listed in the sidebar.</p>
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-zinc-200">
+              <svg className="h-6 w-6 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                />
+              </svg>
+            </div>
+            <p className="text-sm font-medium text-zinc-500">Document preview not available</p>
+            <p className="mt-1 text-xs text-zinc-400">The clauses are listed in the sidebar.</p>
           </div>
         )}
       </div>

--- a/src/app/(app)/contracts/loading.tsx
+++ b/src/app/(app)/contracts/loading.tsx
@@ -1,22 +1,31 @@
-/**
- * Loading skeleton for the contracts list page.
- * Shown while the server streams the contracts list.
- */
 export default function ContractsLoading() {
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
-      <div className="mb-6 h-7 w-48 animate-pulse rounded-md bg-zinc-200" />
-      <div className="space-y-3">
-        {Array.from({ length: 5 }).map((_, i) => (
+    <div className="mx-auto w-full max-w-4xl px-6 py-10 space-y-8">
+      {/* Header skeleton */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <div className="h-6 w-28 animate-pulse rounded-lg bg-zinc-200" />
+          <div className="h-4 w-16 animate-pulse rounded bg-zinc-100" />
+        </div>
+        <div className="h-9 w-36 animate-pulse rounded-lg bg-zinc-200" />
+      </div>
+
+      {/* List skeleton */}
+      <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
+        {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
-            className="flex items-center justify-between rounded-lg border border-zinc-100 bg-white p-4 shadow-sm"
+            className={[
+              "flex items-center gap-4 px-5 py-4",
+              i > 0 ? "border-t border-zinc-100" : "",
+            ].join(" ")}
           >
-            <div className="space-y-2">
-              <div className="h-4 w-56 animate-pulse rounded bg-zinc-200" />
+            <div className="h-9 w-9 flex-shrink-0 animate-pulse rounded-lg bg-zinc-100" />
+            <div className="flex-1 space-y-1.5">
+              <div className="h-4 w-48 animate-pulse rounded bg-zinc-200" />
               <div className="h-3 w-32 animate-pulse rounded bg-zinc-100" />
             </div>
-            <div className="h-6 w-20 animate-pulse rounded-full bg-zinc-100" />
+            <div className="h-5 w-16 animate-pulse rounded-full bg-zinc-100" />
           </div>
         ))}
       </div>

--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -32,13 +32,32 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const STATUS_COLOR: Record<string, string> = {
-  uploaded: "bg-zinc-100 text-zinc-600",
-  processing: "bg-amber-50 text-amber-700",
-  ready: "bg-green-50 text-green-700",
-  failed: "bg-red-50 text-red-600",
+  uploaded: "bg-zinc-100 text-zinc-600 ring-zinc-200",
+  processing: "bg-amber-50 text-amber-700 ring-amber-200",
+  ready: "bg-green-50 text-green-700 ring-green-200",
+  failed: "bg-red-50 text-red-600 ring-red-200",
 };
 
 const PAGE_SIZE = 20;
+
+// Document icon (no emoji)
+function DocIcon() {
+  return (
+    <svg
+      className="h-4 w-4 text-zinc-400"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+      />
+    </svg>
+  );
+}
 
 export default function ContractsPage() {
   const user = useAuthStore((s) => s.user);
@@ -152,47 +171,64 @@ export default function ContractsPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-6 py-8 space-y-8">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+    <div className="mx-auto w-full max-w-4xl px-6 py-10 space-y-8">
+      {/* Page header */}
+      <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-zinc-900">Contracts</h1>
-          <p className="mt-0.5 text-sm text-zinc-500">
-            {total} contract{total !== 1 ? "s" : ""}
-          </p>
+          <h1 className="text-xl font-semibold text-zinc-900">Contracts</h1>
+          {loadState === "success" && (
+            <p className="mt-0.5 text-sm text-zinc-400">
+              {total} contract{total !== 1 ? "s" : ""}
+            </p>
+          )}
         </div>
         <button
           onClick={() => setShowUpload((v) => !v)}
-          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+          className={[
+            "inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+            showUpload
+              ? "bg-zinc-100 text-zinc-900 hover:bg-zinc-200"
+              : "bg-zinc-900 text-white hover:bg-zinc-700",
+          ].join(" ")}
         >
-          + Upload contract
+          {showUpload ? (
+            "Cancel"
+          ) : (
+            <>
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              Upload contract
+            </>
+          )}
         </button>
       </div>
 
       {/* Upload panel */}
       {showUpload && (
-        <div className="rounded-xl border border-zinc-200 bg-white p-6 space-y-4 shadow-sm">
-          <h2 className="text-base font-semibold text-zinc-900">Upload a new contract</h2>
+        <div className="animate-slide-in rounded-xl border border-zinc-200 bg-white p-6 shadow-sm space-y-4">
+          <h2 className="text-sm font-semibold text-zinc-900">Upload a new contract</h2>
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-700">
-              Title (optional)
+            <label className="mb-1.5 block text-sm font-medium text-zinc-700">
+              Title{" "}
+              <span className="font-normal text-zinc-400">(optional)</span>
             </label>
             <input
               type="text"
               value={uploadTitle}
               onChange={(e) => setUploadTitle(e.target.value)}
               placeholder="e.g. NDA with Acme Corp"
-              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+              className="w-full rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
             />
           </div>
           <DropZone onFile={handleFile} disabled={uploading} />
           {uploading && (
-            <div className="space-y-1.5">
+            <div className="space-y-2">
               <div className="flex items-center justify-between text-xs text-zinc-500">
                 <span>Uploading…</span>
-                <span>{uploadPercent}%</span>
+                <span className="font-medium tabular-nums">{uploadPercent}%</span>
               </div>
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-200">
+              <div className="h-1 w-full overflow-hidden rounded-full bg-zinc-100">
                 <div
                   className="h-full rounded-full bg-zinc-700 transition-all duration-150"
                   style={{ width: `${uploadPercent}%` }}
@@ -211,9 +247,14 @@ export default function ContractsPage() {
             .map((u) => (
               <div
                 key={u.jobId}
-                className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm space-y-2"
+                className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm space-y-2.5"
               >
-                <p className="text-sm font-medium text-zinc-800">{u.fileName}</p>
+                <div className="flex items-center gap-2.5">
+                  <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-zinc-100">
+                    <DocIcon />
+                  </div>
+                  <p className="text-sm font-medium text-zinc-800">{u.fileName}</p>
+                </div>
                 <IngestionProgress
                   jobId={u.jobId}
                   onComplete={(job) => handleIngestionComplete(u.jobId, job)}
@@ -231,81 +272,99 @@ export default function ContractsPage() {
         </div>
       )}
 
-      {/* Contract list */}
+      {/* Loading */}
       {loadState === "loading" && (
-        <div className="flex items-center justify-center py-20">
+        <div className="flex items-center justify-center py-24">
           <LoadingSpinner size="md" />
         </div>
       )}
 
+      {/* Error */}
       {loadState === "error" && (
-        <div className="rounded-lg bg-red-50 p-6 text-center text-sm text-red-700 ring-1 ring-red-200">
-          Failed to load contracts.{" "}
+        <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-center">
+          <p className="text-sm font-medium text-red-700">Failed to load contracts.</p>
           <button
             onClick={fetchContracts}
-            className="font-medium underline hover:no-underline"
+            className="mt-2 text-sm font-medium text-red-800 underline underline-offset-2 hover:no-underline"
           >
-            Retry
+            Try again
           </button>
         </div>
       )}
 
+      {/* Empty state */}
       {loadState === "success" && contracts.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-20 text-center text-zinc-400">
-          <svg className="mb-4 h-12 w-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-            />
-          </svg>
-          <p className="text-base font-medium">No contracts yet</p>
-          <p className="mt-1 text-sm">Upload your first contract to get started.</p>
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-200 bg-white py-20 text-center">
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-zinc-100">
+            <svg className="h-6 w-6 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+          </div>
+          <p className="text-sm font-medium text-zinc-700">No contracts yet</p>
+          <p className="mt-1 text-sm text-zinc-400">
+            Upload your first contract to get started.
+          </p>
+          <button
+            onClick={() => setShowUpload(true)}
+            className="mt-5 inline-flex items-center gap-1.5 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Upload contract
+          </button>
         </div>
       )}
 
+      {/* Contract list */}
       {loadState === "success" && contracts.length > 0 && (
-        <div className="divide-y divide-zinc-100 rounded-xl border border-zinc-200 bg-white shadow-sm overflow-hidden">
-          {contracts.map((c) => (
-            <div key={c.id} className="relative flex items-center group">
+        <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
+          {contracts.map((c, i) => (
+            <div
+              key={c.id}
+              className={[
+                "relative flex items-center group",
+                i > 0 ? "border-t border-zinc-100" : "",
+              ].join(" ")}
+            >
               <Link
                 href={`/contracts/${c.id}`}
-                className="flex flex-1 items-center gap-4 px-6 py-4 hover:bg-zinc-50 transition-colors min-w-0"
+                className="flex flex-1 items-center gap-4 px-5 py-4 transition-colors hover:bg-zinc-50 min-w-0"
               >
-                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-zinc-100">
-                  <svg
-                    className="h-5 w-5 text-zinc-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                    />
-                  </svg>
+                {/* File icon */}
+                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-zinc-100 transition-colors group-hover:bg-zinc-200">
+                  <DocIcon />
                 </div>
 
+                {/* Title + meta */}
                 <div className="flex-1 min-w-0">
-                  <p className="truncate text-sm font-medium text-zinc-900">{c.title}</p>
-                  <p className="text-xs text-zinc-400 mt-0.5">
-                    {c.fileName} · {formatBytes(c.fileSize)} · {formatDate(c.createdAt)}
+                  <p className="truncate text-sm font-medium text-zinc-900 leading-snug">
+                    {c.title}
+                  </p>
+                  <p className="mt-0.5 text-xs text-zinc-400 truncate">
+                    {c.fileName}
+                    {c.fileSize ? ` · ${formatBytes(c.fileSize)}` : ""}
+                    {c.createdAt ? ` · ${formatDate(c.createdAt)}` : ""}
                   </p>
                 </div>
 
+                {/* Status badge */}
                 <span
-                  className={`flex-shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                    STATUS_COLOR[c.status] ?? "bg-zinc-100 text-zinc-600"
+                  className={`flex-shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${
+                    STATUS_COLOR[c.status] ?? "bg-zinc-100 text-zinc-600 ring-zinc-200"
                   }`}
                 >
                   {STATUS_LABEL[c.status] ?? c.status}
                 </span>
 
+                {/* Chevron */}
                 <svg
-                  className="h-4 w-4 flex-shrink-0 text-zinc-300"
+                  className="h-4 w-4 flex-shrink-0 text-zinc-300 transition-colors group-hover:text-zinc-400"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -314,14 +373,19 @@ export default function ContractsPage() {
                 </svg>
               </Link>
 
+              {/* Delete button (visible on hover) */}
               <button
                 onClick={(e) => openDeleteDialog(e, c)}
-                className="mr-4 flex-shrink-0 rounded-md p-1.5 text-zinc-300 opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-500 transition-all"
+                className="mr-4 flex-shrink-0 rounded-md p-1.5 text-zinc-300 opacity-0 group-hover:opacity-100 transition-all hover:bg-red-50 hover:text-red-500"
                 title="Delete contract"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
                 </svg>
               </button>
             </div>
@@ -335,38 +399,59 @@ export default function ContractsPage() {
           <button
             onClick={loadMore}
             disabled={loadMoreState === "loading"}
-            className="rounded-md border border-zinc-300 px-5 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+            className="rounded-lg border border-zinc-200 px-5 py-2 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-50 disabled:opacity-50"
           >
-            {loadMoreState === "loading"
-              ? "Loading…"
-              : `Load more (${total - contracts.length} remaining)`}
+            {loadMoreState === "loading" ? (
+              <span className="flex items-center gap-2">
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600" />
+                Loading…
+              </span>
+            ) : (
+              `Load more (${total - contracts.length} remaining)`
+            )}
           </button>
         </div>
       )}
 
       {/* Delete confirmation dialog */}
       {deleteDialog.open && (
-        <Modal onClose={() => !deleting && setDeleteDialog({ open: false, contractId: "", contractTitle: "" })}>
-          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <Modal
+          onClose={() =>
+            !deleting &&
+            setDeleteDialog({ open: false, contractId: "", contractTitle: "" })
+          }
+        >
+          <div className="w-full max-w-sm animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
             <h3 className="text-base font-semibold text-zinc-900">Delete contract?</h3>
             <p className="mt-2 text-sm text-zinc-500">
-              <span className="font-medium text-zinc-800">&ldquo;{deleteDialog.contractTitle}&rdquo;</span>{" "}
+              <span className="font-medium text-zinc-800">
+                &ldquo;{deleteDialog.contractTitle}&rdquo;
+              </span>{" "}
               will be permanently deleted. This cannot be undone.
             </p>
-            <div className="mt-5 flex justify-end gap-2">
+            <div className="mt-6 flex justify-end gap-2">
               <button
-                onClick={() => setDeleteDialog({ open: false, contractId: "", contractTitle: "" })}
+                onClick={() =>
+                  setDeleteDialog({ open: false, contractId: "", contractTitle: "" })
+                }
                 disabled={deleting}
-                className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+                className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:opacity-50"
               >
                 Cancel
               </button>
               <button
                 onClick={handleConfirmDelete}
                 disabled={deleting}
-                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
               >
-                {deleting ? "Deleting…" : "Delete"}
+                {deleting ? (
+                  <span className="flex items-center gap-2">
+                    <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+                    Deleting…
+                  </span>
+                ) : (
+                  "Delete"
+                )}
               </button>
             </div>
           </div>

--- a/src/app/(app)/error.tsx
+++ b/src/app/(app)/error.tsx
@@ -7,21 +7,15 @@ interface ErrorProps {
   reset: () => void;
 }
 
-/**
- * App-level error boundary for the (app) route segment.
- * Catches unexpected rendering/runtime errors and prevents a blank white screen.
- * This file must be a Client Component as required by Next.js App Router.
- */
 export default function AppError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    // Log error for monitoring (avoid console.log in production — use sentry etc.)
     // eslint-disable-next-line no-console
     console.error("[AppError boundary]", error);
   }, [error]);
 
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-6 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-5 px-6 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-red-50 ring-1 ring-red-200">
         <svg
           className="h-6 w-6 text-red-500"
           fill="none"
@@ -37,7 +31,7 @@ export default function AppError({ error, reset }: ErrorProps) {
         </svg>
       </div>
 
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <h2 className="text-base font-semibold text-zinc-900">
           Something went wrong
         </h2>
@@ -51,7 +45,7 @@ export default function AppError({ error, reset }: ErrorProps) {
 
       <button
         onClick={reset}
-        className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+        className="rounded-lg bg-zinc-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
       >
         Try again
       </button>

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,24 +1,50 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { OrgSwitcher } from "@/components/ui/OrgSwitcher";
 
+function NavLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const isActive = pathname === href || pathname.startsWith(href + "/");
+
+  return (
+    <Link
+      href={href}
+      className={[
+        "relative text-sm font-medium transition-colors duration-150",
+        isActive
+          ? "text-zinc-900"
+          : "text-zinc-500 hover:text-zinc-800",
+      ].join(" ")}
+    >
+      {children}
+      {isActive && (
+        <span className="absolute -bottom-[1px] left-0 right-0 h-[2px] rounded-full bg-zinc-900" />
+      )}
+    </Link>
+  );
+}
+
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const { accessToken, user, setAuth, clearAuth } = useAuthStore();
 
-  // On mount, if no token in memory, attempt a silent refresh.
   useEffect(() => {
     if (accessToken) return;
 
     api
       .getMe()
       .then((user) => {
-        // getMe() triggers a token refresh internally; grab the refreshed token.
         const token = useAuthStore.getState().accessToken ?? "";
         setAuth(token, user);
       })
@@ -26,7 +52,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         clearAuth();
         router.replace("/login");
       });
-  }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleLogout() {
     try {
@@ -37,51 +63,65 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     }
   }
 
-  // While we have a valid token (or are re-hydrating) show the shell.
   return (
     <div className="flex min-h-screen flex-col bg-zinc-50">
       {/* Top nav */}
-      <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-zinc-200 bg-white px-6">
-        <Link href="/contracts" className="text-lg font-bold tracking-tight text-zinc-900">
-          SignSafe
-        </Link>
-
-        <nav className="flex items-center gap-6">
-          <Link
-            href="/contracts"
-            className="text-sm font-medium text-zinc-600 hover:text-zinc-900"
-          >
-            Contracts
-          </Link>
-          {user?.permissions?.includes("audit:read") && (
+      <header className="sticky top-0 z-30 border-b border-zinc-200 bg-white">
+        <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between px-6">
+          {/* Left: logo + nav */}
+          <div className="flex items-center gap-8">
             <Link
-              href="/audit-logs"
-              className="text-sm font-medium text-zinc-600 hover:text-zinc-900"
+              href="/contracts"
+              className="flex items-center gap-2 text-sm font-semibold tracking-tight text-zinc-900"
             >
-              Audit Log
+              {/* Shield icon */}
+              <svg
+                className="h-5 w-5 text-zinc-900"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+              </svg>
+              SignSafe
             </Link>
-          )}
-        </nav>
 
-        <div className="flex items-center gap-3">
-          <OrgSwitcher />
-          {user && (
-            <span className="text-sm text-zinc-500 hidden sm:inline">
-              {user.fullName}
-            </span>
-          )}
-          <Link
-            href="/settings"
-            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-50"
-          >
-            Account
-          </Link>
-          <button
-            onClick={handleLogout}
-            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-50"
-          >
-            Sign out
-          </button>
+            <nav className="flex items-center gap-6">
+              <NavLink href="/contracts">Contracts</NavLink>
+              {user?.permissions?.includes("audit:read") && (
+                <NavLink href="/audit-logs">Audit Log</NavLink>
+              )}
+            </nav>
+          </div>
+
+          {/* Right: org switcher + user */}
+          <div className="flex items-center gap-3">
+            <OrgSwitcher />
+
+            {user && (
+              <span className="hidden text-sm text-zinc-500 sm:inline">
+                {user.fullName}
+              </span>
+            )}
+
+            <div className="flex items-center gap-1.5">
+              <Link
+                href="/settings"
+                className="rounded-md px-3 py-1.5 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900"
+              >
+                Settings
+              </Link>
+              <button
+                onClick={handleLogout}
+                className="rounded-md px-3 py-1.5 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900"
+              >
+                Sign out
+              </button>
+            </div>
+          </div>
         </div>
       </header>
 

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,11 +1,7 @@
-/**
- * Top-level loading skeleton for the (app) route group.
- * Shown while any page inside (app) is streaming its initial server render.
- */
 export default function AppLoading() {
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-200 border-t-zinc-900" />
+      <div className="h-7 w-7 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-600" />
     </div>
   );
 }

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -25,21 +25,29 @@ export default function ForgotPasswordPage() {
     }
   }
 
+  const inputCls =
+    "w-full rounded-lg border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+
   if (state === "success") {
     return (
-      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 mx-auto">
+      <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
           <svg className="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 className="text-lg font-semibold text-zinc-900">Check your inbox</h2>
-        <p className="text-sm text-zinc-500">
-          If an account exists for{" "}
-          <span className="font-medium text-zinc-900">{email}</span>, we&apos;ve
-          sent a password reset link.
-        </p>
-        <Link href="/login" className="text-sm font-medium text-zinc-900 hover:underline">
+        <div>
+          <h2 className="text-base font-semibold text-zinc-900">Check your inbox</h2>
+          <p className="mt-2 text-sm text-zinc-500">
+            If an account exists for{" "}
+            <span className="font-medium text-zinc-900">{email}</span>, we&apos;ve
+            sent a password reset link.
+          </p>
+        </div>
+        <Link
+          href="/login"
+          className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+        >
           Back to sign in
         </Link>
       </div>
@@ -47,23 +55,23 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200">
-      <h2 className="mb-2 text-center text-xl font-semibold text-zinc-900">
-        Reset your password
-      </h2>
-      <p className="mb-6 text-center text-sm text-zinc-500">
-        Enter your email and we&apos;ll send you a reset link.
-      </p>
+    <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
+      <div className="mb-7 text-center">
+        <h2 className="text-lg font-semibold text-zinc-900">Reset your password</h2>
+        <p className="mt-1 text-sm text-zinc-500">
+          Enter your email and we&apos;ll send you a reset link.
+        </p>
+      </div>
 
       {state === "error" && error && (
-        <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700 ring-1 ring-red-200">
+        <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {error}
         </div>
       )}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="email" className="mb-1 block text-sm font-medium text-zinc-700">
+          <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-zinc-700">
             Email
           </label>
           <input
@@ -73,7 +81,7 @@ export default function ForgotPasswordPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="you@example.com"
           />
         </div>
@@ -81,15 +89,25 @@ export default function ForgotPasswordPage() {
         <button
           type="submit"
           disabled={state === "loading"}
-          className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-1 w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {state === "loading" ? "Sending…" : "Send reset link"}
+          {state === "loading" ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+              Sending…
+            </span>
+          ) : (
+            "Send reset link"
+          )}
         </button>
       </form>
 
       <p className="mt-6 text-center text-sm text-zinc-500">
         Remember your password?{" "}
-        <Link href="/login" className="font-medium text-zinc-900 hover:underline">
+        <Link
+          href="/login"
+          className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+        >
           Sign in
         </Link>
       </p>

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -4,16 +4,41 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4">
-      <div className="w-full max-w-sm space-y-8">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12">
+      {/* Background subtle grid */}
+      <div
+        className="pointer-events-none fixed inset-0 opacity-[0.03]"
+        style={{
+          backgroundImage:
+            "linear-gradient(#18181b 1px, transparent 1px), linear-gradient(90deg, #18181b 1px, transparent 1px)",
+          backgroundSize: "40px 40px",
+        }}
+      />
+
+      <div className="relative w-full max-w-sm space-y-8">
+        {/* Branding */}
         <div className="text-center">
-          <h1 className="text-3xl font-bold tracking-tight text-zinc-900">
+          <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-zinc-900 shadow-sm">
+            <svg
+              className="h-6 w-6 text-white"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold tracking-tight text-zinc-900">
             SignSafe
           </h1>
-          <p className="mt-1 text-sm text-zinc-500">
+          <p className="mt-1.5 text-sm text-zinc-500">
             AI-powered contract risk analysis
           </p>
         </div>
+
         {children}
       </div>
     </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -64,29 +64,33 @@ export default function LoginPage() {
     }
   }
 
+  const inputCls =
+    "w-full rounded-lg border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+
   return (
-    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200">
-      <h2 className="mb-6 text-center text-xl font-semibold text-zinc-900">
-        Sign in to your account
-      </h2>
+    <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
+      <div className="mb-7 text-center">
+        <h2 className="text-lg font-semibold text-zinc-900">Welcome back</h2>
+        <p className="mt-1 text-sm text-zinc-500">Sign in to your account</p>
+      </div>
 
       {formState.error && (
-        <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700 ring-1 ring-red-200">
+        <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           <p>{formState.error}</p>
           {formState.showResend && (
-            <div className="mt-2">
+            <div className="mt-2.5">
               {resendState === "sent" ? (
-                <p className="text-green-700">
-                  Verification email sent. Please check your inbox.
+                <p className="font-medium text-green-700">
+                  Verification email sent. Check your inbox.
                 </p>
               ) : resendState === "error" ? (
-                <p className="text-red-700">Failed to send. Please try again later.</p>
+                <p>Failed to send. Please try again later.</p>
               ) : (
                 <button
                   type="button"
                   onClick={handleResend}
                   disabled={resendState === "sending"}
-                  className="mt-1 text-xs font-medium text-red-800 underline hover:text-red-900 disabled:opacity-50"
+                  className="text-xs font-semibold text-red-800 underline underline-offset-2 hover:text-red-900 disabled:opacity-50"
                 >
                   {resendState === "sending"
                     ? "Sending…"
@@ -102,7 +106,7 @@ export default function LoginPage() {
         <div>
           <label
             htmlFor="email"
-            className="mb-1 block text-sm font-medium text-zinc-700"
+            className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
             Email
           </label>
@@ -113,18 +117,26 @@ export default function LoginPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="you@example.com"
           />
         </div>
 
         <div>
-          <label
-            htmlFor="password"
-            className="mb-1 block text-sm font-medium text-zinc-700"
-          >
-            Password
-          </label>
+          <div className="mb-1.5 flex items-center justify-between">
+            <label
+              htmlFor="password"
+              className="text-sm font-medium text-zinc-700"
+            >
+              Password
+            </label>
+            <Link
+              href="/forgot-password"
+              className="text-xs text-zinc-400 transition-colors hover:text-zinc-700"
+            >
+              Forgot password?
+            </Link>
+          </div>
           <input
             id="password"
             type="password"
@@ -132,26 +144,24 @@ export default function LoginPage() {
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="••••••••"
           />
-        </div>
-
-        <div className="flex items-center justify-end">
-          <Link
-            href="/forgot-password"
-            className="text-xs text-zinc-500 hover:text-zinc-700 hover:underline"
-          >
-            Forgot password?
-          </Link>
         </div>
 
         <button
           type="submit"
           disabled={formState.status === "loading"}
-          className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-1 w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {formState.status === "loading" ? "Signing in…" : "Sign in"}
+          {formState.status === "loading" ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+              Signing in…
+            </span>
+          ) : (
+            "Sign in"
+          )}
         </button>
       </form>
 
@@ -159,7 +169,7 @@ export default function LoginPage() {
         No account?{" "}
         <Link
           href="/signup"
-          className="font-medium text-zinc-900 hover:underline"
+          className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
           Create one
         </Link>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -46,16 +46,19 @@ function ResetPasswordForm() {
     }
   }
 
+  const inputCls =
+    "w-full rounded-lg border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+
   if (state === "missing-token") {
     return (
-      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
-        <h2 className="text-lg font-semibold text-zinc-900">Invalid link</h2>
+      <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+        <h2 className="text-base font-semibold text-zinc-900">Invalid link</h2>
         <p className="text-sm text-zinc-500">
           This password reset link is missing a token.
         </p>
         <Link
           href="/forgot-password"
-          className="text-sm font-medium text-zinc-900 hover:underline"
+          className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
           Request a new reset link
         </Link>
@@ -65,8 +68,8 @@ function ResetPasswordForm() {
 
   if (state === "success") {
     return (
-      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 mx-auto">
+      <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
           <svg
             className="h-6 w-6 text-green-600"
             fill="none"
@@ -81,15 +84,15 @@ function ResetPasswordForm() {
             />
           </svg>
         </div>
-        <h2 className="text-lg font-semibold text-zinc-900">
-          Password updated
-        </h2>
-        <p className="text-sm text-zinc-500">
-          Your password has been reset. Redirecting to sign in…
-        </p>
+        <div>
+          <h2 className="text-base font-semibold text-zinc-900">Password updated</h2>
+          <p className="mt-2 text-sm text-zinc-500">
+            Your password has been reset. Redirecting to sign in…
+          </p>
+        </div>
         <Link
           href="/login"
-          className="text-sm font-medium text-zinc-900 hover:underline"
+          className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
           Go to sign in
         </Link>
@@ -98,16 +101,14 @@ function ResetPasswordForm() {
   }
 
   return (
-    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200">
-      <h2 className="mb-2 text-center text-xl font-semibold text-zinc-900">
-        Set new password
-      </h2>
-      <p className="mb-6 text-center text-sm text-zinc-500">
-        Enter your new password below.
-      </p>
+    <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
+      <div className="mb-7 text-center">
+        <h2 className="text-lg font-semibold text-zinc-900">Set new password</h2>
+        <p className="mt-1 text-sm text-zinc-500">Enter your new password below.</p>
+      </div>
 
       {state === "error" && error && (
-        <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700 ring-1 ring-red-200">
+        <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {error}
         </div>
       )}
@@ -116,7 +117,7 @@ function ResetPasswordForm() {
         <div>
           <label
             htmlFor="new-password"
-            className="mb-1 block text-sm font-medium text-zinc-700"
+            className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
             New password
           </label>
@@ -128,7 +129,7 @@ function ResetPasswordForm() {
             minLength={8}
             value={newPassword}
             onChange={(e) => setNewPassword(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="Min. 8 characters"
           />
         </div>
@@ -136,7 +137,7 @@ function ResetPasswordForm() {
         <div>
           <label
             htmlFor="confirm-password"
-            className="mb-1 block text-sm font-medium text-zinc-700"
+            className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
             Confirm password
           </label>
@@ -147,7 +148,7 @@ function ResetPasswordForm() {
             required
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="Repeat password"
           />
         </div>
@@ -159,9 +160,16 @@ function ResetPasswordForm() {
         <button
           type="submit"
           disabled={state === "loading"}
-          className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-1 w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {state === "loading" ? "Updating…" : "Reset password"}
+          {state === "loading" ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+              Updating…
+            </span>
+          ) : (
+            "Reset password"
+          )}
         </button>
       </form>
 
@@ -169,7 +177,7 @@ function ResetPasswordForm() {
         Remember your password?{" "}
         <Link
           href="/login"
-          className="font-medium text-zinc-900 hover:underline"
+          className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
           Sign in
         </Link>
@@ -182,7 +190,7 @@ export default function ResetPasswordPage() {
   return (
     <Suspense
       fallback={
-        <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 flex justify-center">
+        <div className="rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm flex justify-center">
           <LoadingSpinner size="sm" />
         </div>
       }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -47,10 +47,13 @@ export default function SignupPage() {
     }
   }
 
+  const inputCls =
+    "w-full rounded-lg border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+
   if (formState.status === "success") {
     return (
-      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 mx-auto">
+      <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
           <svg
             className="h-6 w-6 text-green-600"
             fill="none"
@@ -65,15 +68,17 @@ export default function SignupPage() {
             />
           </svg>
         </div>
-        <h2 className="text-lg font-semibold text-zinc-900">Check your inbox</h2>
-        <p className="text-sm text-zinc-500">
-          We&apos;ve sent a verification link to{" "}
-          <span className="font-medium text-zinc-900">{email}</span>. Click it
-          to activate your account.
-        </p>
+        <div>
+          <h2 className="text-base font-semibold text-zinc-900">Check your inbox</h2>
+          <p className="mt-2 text-sm text-zinc-500">
+            We&apos;ve sent a verification link to{" "}
+            <span className="font-medium text-zinc-900">{email}</span>. Click it
+            to activate your account.
+          </p>
+        </div>
         <button
           onClick={() => router.push("/login")}
-          className="mt-2 text-sm font-medium text-zinc-900 hover:underline"
+          className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
           Back to sign in
         </button>
@@ -82,13 +87,14 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200">
-      <h2 className="mb-6 text-center text-xl font-semibold text-zinc-900">
-        Create your account
-      </h2>
+    <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
+      <div className="mb-7 text-center">
+        <h2 className="text-lg font-semibold text-zinc-900">Create your account</h2>
+        <p className="mt-1 text-sm text-zinc-500">Get started for free</p>
+      </div>
 
       {formState.error && (
-        <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700 ring-1 ring-red-200">
+        <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {formState.error}
         </div>
       )}
@@ -97,7 +103,7 @@ export default function SignupPage() {
         <div>
           <label
             htmlFor="fullName"
-            className="mb-1 block text-sm font-medium text-zinc-700"
+            className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
             Full name
           </label>
@@ -108,7 +114,7 @@ export default function SignupPage() {
             required
             value={fullName}
             onChange={(e) => setFullName(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="Jane Doe"
           />
         </div>
@@ -116,7 +122,7 @@ export default function SignupPage() {
         <div>
           <label
             htmlFor="email"
-            className="mb-1 block text-sm font-medium text-zinc-700"
+            className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
             Email
           </label>
@@ -127,7 +133,7 @@ export default function SignupPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="you@example.com"
           />
         </div>
@@ -135,7 +141,7 @@ export default function SignupPage() {
         <div>
           <label
             htmlFor="password"
-            className="mb-1 block text-sm font-medium text-zinc-700"
+            className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
             Password
           </label>
@@ -147,25 +153,31 @@ export default function SignupPage() {
             minLength={8}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            className={inputCls}
             placeholder="Min. 8 characters"
           />
         </div>
 
-        <label className="flex items-start gap-2 cursor-pointer">
+        <label className="flex cursor-pointer items-start gap-3 pt-1">
           <input
             type="checkbox"
             checked={agreed}
             onChange={(e) => setAgreed(e.target.checked)}
-            className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-500"
+            className="mt-0.5 h-4 w-4 rounded border-zinc-300 accent-zinc-900"
           />
           <span className="text-sm text-zinc-600">
             I agree to the{" "}
-            <a href="/terms" className="font-medium text-zinc-900 hover:underline">
+            <a
+              href="/terms"
+              className="font-medium text-zinc-900 hover:underline"
+            >
               Terms of Service
             </a>{" "}
             and{" "}
-            <a href="/privacy" className="font-medium text-zinc-900 hover:underline">
+            <a
+              href="/privacy"
+              className="font-medium text-zinc-900 hover:underline"
+            >
               Privacy Policy
             </a>
           </span>
@@ -174,15 +186,25 @@ export default function SignupPage() {
         <button
           type="submit"
           disabled={formState.status === "loading"}
-          className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-1 w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {formState.status === "loading" ? "Creating account…" : "Create account"}
+          {formState.status === "loading" ? (
+            <span className="flex items-center justify-center gap-2">
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+              Creating account…
+            </span>
+          ) : (
+            "Create account"
+          )}
         </button>
       </form>
 
       <p className="mt-6 text-center text-sm text-zinc-500">
         Already have an account?{" "}
-        <Link href="/login" className="font-medium text-zinc-900 hover:underline">
+        <Link
+          href="/login"
+          className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+        >
           Sign in
         </Link>
       </p>

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -36,17 +36,17 @@ function VerifyEmailContent() {
 
   if (state === "loading") {
     return (
-      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center">
-        <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-900" />
-        <p className="mt-4 text-sm text-zinc-500">Verifying your email…</p>
+      <div className="animate-fade-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+        <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900" />
+        <p className="text-sm text-zinc-500">Verifying your email…</p>
       </div>
     );
   }
 
   if (state === "success") {
     return (
-      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 mx-auto">
+      <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
           <svg
             className="h-6 w-6 text-green-600"
             fill="none"
@@ -61,23 +61,26 @@ function VerifyEmailContent() {
             />
           </svg>
         </div>
-        <h2 className="text-lg font-semibold text-zinc-900">Email verified!</h2>
-        <p className="text-sm text-zinc-500">
-          Redirecting you to sign in…
-        </p>
+        <div>
+          <h2 className="text-base font-semibold text-zinc-900">Email verified!</h2>
+          <p className="mt-2 text-sm text-zinc-500">Redirecting you to sign in…</p>
+        </div>
       </div>
     );
   }
 
   if (state === "missing") {
     return (
-      <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
-        <h2 className="text-lg font-semibold text-zinc-900">Missing token</h2>
+      <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+        <h2 className="text-base font-semibold text-zinc-900">Missing token</h2>
         <p className="text-sm text-zinc-500">
           The verification link is invalid or expired. Check your inbox for the
           latest verification email.
         </p>
-        <Link href="/login" className="text-sm font-medium text-zinc-900 hover:underline">
+        <Link
+          href="/login"
+          className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+        >
           Back to sign in
         </Link>
       </div>
@@ -85,8 +88,8 @@ function VerifyEmailContent() {
   }
 
   return (
-    <div className="rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 text-center space-y-4">
-      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 mx-auto">
+    <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
         <svg
           className="h-6 w-6 text-red-600"
           fill="none"
@@ -101,11 +104,16 @@ function VerifyEmailContent() {
           />
         </svg>
       </div>
-      <h2 className="text-lg font-semibold text-zinc-900">Verification failed</h2>
-      {errorMsg && (
-        <p className="text-sm text-red-600">{errorMsg}</p>
-      )}
-      <Link href="/login" className="text-sm font-medium text-zinc-900 hover:underline">
+      <div>
+        <h2 className="text-base font-semibold text-zinc-900">Verification failed</h2>
+        {errorMsg && (
+          <p className="mt-2 text-sm text-red-600">{errorMsg}</p>
+        )}
+      </div>
+      <Link
+        href="/login"
+        className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+      >
         Back to sign in
       </Link>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,34 +1,56 @@
 @import "tailwindcss";
 
+/* ── Design tokens ──────────────────────────────────────────────────────────── */
+
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Backgrounds */
+  --bg-base: #f9f9f9;
+  --bg-surface: #ffffff;
+
+  /* Text */
+  --text-primary: #111111;
+  --text-secondary: #525252;
+  --text-muted: #a1a1aa;
+
+  /* Borders */
+  --border-default: #e4e4e7;
+  --border-subtle: #f4f4f5;
+
+  /* Brand / accent */
+  --accent: #18181b;
+  --accent-hover: #27272a;
+
+  /* Status */
+  --status-success: #16a34a;
+  --status-warning: #d97706;
+  --status-error: #dc2626;
+  --status-info: #2563eb;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-background: var(--bg-base);
+  --color-foreground: var(--text-primary);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+/* ── Base ───────────────────────────────────────────────────────────────────── */
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-@keyframes slide-in {
+/* ── Animations ─────────────────────────────────────────────────────────────── */
+
+@keyframes slide-in-up {
   from {
     opacity: 0;
-    transform: translateY(8px);
+    transform: translateY(6px);
   }
   to {
     opacity: 1;
@@ -36,6 +58,57 @@ body {
   }
 }
 
+@keyframes slide-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 .animate-slide-in {
-  animation: slide-in 0.18s ease-out forwards;
+  animation: slide-in-up 0.15s ease-out forwards;
+}
+
+.animate-slide-in-right {
+  animation: slide-in-right 0.15s ease-out forwards;
+}
+
+.animate-fade-in {
+  animation: fade-in 0.15s ease-out forwards;
+}
+
+/* ── Focus ring ─────────────────────────────────────────────────────────────── */
+
+*:focus-visible {
+  outline: 2px solid #18181b;
+  outline-offset: 2px;
+}
+
+/* ── Scrollbar ──────────────────────────────────────────────────────────────── */
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #d4d4d8;
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #a1a1aa;
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,18 +1,13 @@
 import Link from "next/link";
 
-/**
- * Root not-found page.
- * Rendered when notFound() is called anywhere in the app, or when a URL
- * does not match any route. Next.js returns HTTP 404 for non-streamed responses.
- */
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100">
-        <span className="text-2xl font-bold text-zinc-400">404</span>
+    <div className="flex min-h-screen flex-col items-center justify-center gap-5 px-6 text-center bg-zinc-50">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white ring-1 ring-zinc-200 shadow-sm">
+        <span className="text-lg font-bold text-zinc-400">404</span>
       </div>
 
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <h1 className="text-base font-semibold text-zinc-900">
           Page not found
         </h1>
@@ -23,7 +18,7 @@ export default function NotFound() {
 
       <Link
         href="/contracts"
-        className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+        className="rounded-lg bg-zinc-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
       >
         Go to contracts
       </Link>

--- a/src/components/contract/EditContractModal.tsx
+++ b/src/components/contract/EditContractModal.tsx
@@ -12,6 +12,11 @@ interface EditContractModalProps {
   onSaved: (updated: Contract) => void;
 }
 
+const inputCls =
+  "w-full rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10 disabled:opacity-50";
+
+const labelCls = "mb-1.5 block text-sm font-medium text-zinc-700";
+
 export default function EditContractModal({
   contract,
   onClose,
@@ -26,10 +31,6 @@ export default function EditContractModal({
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const inputCls =
-    "w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500";
-  const labelCls = "mb-1 block text-xs font-medium text-zinc-600";
 
   async function handleSave() {
     if (!form.title?.trim()) {
@@ -58,9 +59,23 @@ export default function EditContractModal({
 
   return (
     <Modal onClose={saving ? undefined : onClose}>
-      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
-        <h3 className="text-base font-semibold text-zinc-900">Edit contract</h3>
-        <div className="mt-4 space-y-4">
+      <div className="w-full max-w-md animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
+        {/* Header */}
+        <div className="mb-5 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-zinc-900">Edit contract</h3>
+          <button
+            onClick={saving ? undefined : onClose}
+            disabled={saving}
+            className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 disabled:opacity-50"
+            aria-label="Close"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="space-y-4">
           <div>
             <label className={labelCls}>Title</label>
             <input
@@ -68,30 +83,36 @@ export default function EditContractModal({
               value={form.title ?? ""}
               onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
               className={inputCls}
+              placeholder="e.g. NDA with Acme Corp"
             />
           </div>
-          <div>
-            <label className={labelCls}>Language</label>
-            <input
-              type="text"
-              value={form.language ?? ""}
-              onChange={(e) => setForm((f) => ({ ...f, language: e.target.value }))}
-              placeholder="e.g. ko, en"
-              className={inputCls}
-            />
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>Language</label>
+              <input
+                type="text"
+                value={form.language ?? ""}
+                onChange={(e) => setForm((f) => ({ ...f, language: e.target.value }))}
+                placeholder="e.g. ko, en"
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>Contract type</label>
+              <input
+                type="text"
+                value={form.contractType ?? ""}
+                onChange={(e) => setForm((f) => ({ ...f, contractType: e.target.value }))}
+                placeholder="e.g. NDA"
+                className={inputCls}
+              />
+            </div>
           </div>
           <div>
-            <label className={labelCls}>Contract type</label>
-            <input
-              type="text"
-              value={form.contractType ?? ""}
-              onChange={(e) => setForm((f) => ({ ...f, contractType: e.target.value }))}
-              placeholder="e.g. NDA, Service Agreement"
-              className={inputCls}
-            />
-          </div>
-          <div>
-            <label className={labelCls}>Tags (JSON array)</label>
+            <label className={labelCls}>
+              Tags{" "}
+              <span className="text-xs font-normal text-zinc-400">(JSON array)</span>
+            </label>
             <input
               type="text"
               value={form.tags ?? ""}
@@ -101,7 +122,10 @@ export default function EditContractModal({
             />
           </div>
           <div>
-            <label className={labelCls}>Parties (JSON array)</label>
+            <label className={labelCls}>
+              Parties{" "}
+              <span className="text-xs font-normal text-zinc-400">(JSON array)</span>
+            </label>
             <input
               type="text"
               value={form.parties ?? ""}
@@ -112,22 +136,33 @@ export default function EditContractModal({
           </div>
         </div>
 
-        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        {error && (
+          <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3.5 py-2.5 text-sm text-red-600">
+            {error}
+          </div>
+        )}
 
-        <div className="mt-4 flex justify-end gap-2">
+        <div className="mt-6 flex justify-end gap-2">
           <button
             onClick={onClose}
             disabled={saving}
-            className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+            className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:opacity-50"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
             disabled={saving}
-            className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+            className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50"
           >
-            {saving ? "Saving…" : "Save changes"}
+            {saving ? (
+              <span className="flex items-center gap-2">
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+                Saving…
+              </span>
+            ) : (
+              "Save changes"
+            )}
           </button>
         </div>
       </div>

--- a/src/components/evidence/CitationCard.tsx
+++ b/src/components/evidence/CitationCard.tsx
@@ -10,19 +10,40 @@ interface CitationCardProps {
   contractId: string;
 }
 
-const TYPE_ICON: Record<string, string> = {
-  case: "⚖️",
-  policy: "📋",
-  guideline: "📌",
-  clause: "📄",
-};
-
+// Type label without emoji
 const TYPE_LABEL: Record<string, string> = {
   case: "Case law",
   policy: "Policy",
   guideline: "Guideline",
   clause: "Similar clause",
 };
+
+// Type icon — SVG only
+function TypeIcon({ type }: { type: string }) {
+  if (type === "case") {
+    return (
+      <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+          d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+      </svg>
+    );
+  }
+  if (type === "policy") {
+    return (
+      <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+      </svg>
+    );
+  }
+  // default document icon
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+    </svg>
+  );
+}
 
 interface SnippetModal {
   open: boolean;
@@ -66,66 +87,82 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
 
   return (
     <>
-      <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 space-y-1.5">
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50/60 p-3.5 space-y-2">
+        {/* Header row */}
         <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-1.5">
-            <span className="text-sm" role="img" aria-label={citation.type}>
-              {TYPE_ICON[citation.type] ?? "📄"}
-            </span>
-            <span className="text-xs font-medium text-zinc-500">
+          <div className="flex items-center gap-1.5 text-zinc-400">
+            <TypeIcon type={citation.type} />
+            <span className="text-xs font-medium">
               {TYPE_LABEL[citation.type] ?? citation.type}
             </span>
           </div>
           {citation.score != null && (
-            <span className="text-xs text-zinc-400">
+            <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-500">
               {Math.round(citation.score * 100)}% match
             </span>
           )}
         </div>
 
-        <p className="text-sm font-medium text-zinc-800">{citation.title}</p>
+        {/* Title */}
+        <p className="text-xs font-semibold text-zinc-800 leading-snug">
+          {citation.title}
+        </p>
 
-        <p className={`text-xs text-zinc-500 leading-relaxed ${expanded ? "" : "line-clamp-2"}`}>
+        {/* Snippet */}
+        <p
+          className={`text-xs text-zinc-500 leading-relaxed ${
+            expanded ? "" : "line-clamp-2"
+          }`}
+        >
           {citation.snippet}
         </p>
 
+        {/* Actions */}
         <div className="flex items-center gap-3 pt-0.5">
-          <button
-            onClick={() => setExpanded((v) => !v)}
-            className="text-xs text-zinc-400 hover:text-zinc-600"
-          >
-            {expanded ? "Show less" : "Show more"}
-          </button>
+          {citation.snippet && citation.snippet.length > 120 && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-600"
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          )}
 
           {citation.type === "clause" && (citation.source ?? contractId) && (
             <button
               onClick={handleViewSource}
-              className="text-xs text-zinc-400 hover:text-zinc-600 hover:underline"
+              className="text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-600 hover:underline"
             >
               View source
             </button>
           )}
         </div>
 
+        {/* Why relevant */}
         {citation.whyRelevant && (
-          <div className="rounded bg-white px-2 py-1.5 ring-1 ring-zinc-200">
-            <p className="text-xs text-zinc-500 italic">
-              Why relevant: {citation.whyRelevant}
+          <div className="rounded-md bg-white px-3 py-2 ring-1 ring-zinc-200">
+            <p className="text-xs text-zinc-500 leading-relaxed">
+              <span className="font-medium text-zinc-600">Why relevant: </span>
+              {citation.whyRelevant}
             </p>
           </div>
         )}
       </div>
 
+      {/* Source snippet modal */}
       {modal.open && (
         <Modal onClose={() => setModal((s) => ({ ...s, open: false }))}>
-          <div className="w-full max-w-lg max-h-[70vh] overflow-y-auto rounded-xl bg-white p-6 shadow-xl">
-            <div className="flex items-center justify-between mb-4">
+          <div className="w-full max-w-lg animate-slide-in max-h-[70vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
+            <div className="mb-5 flex items-center justify-between">
               <h3 className="text-base font-semibold text-zinc-900">Source snippet</h3>
               <button
                 onClick={() => setModal((s) => ({ ...s, open: false }))}
-                className="text-zinc-400 hover:text-zinc-700"
+                className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+                aria-label="Close"
               >
-                ✕
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
               </button>
             </div>
 
@@ -134,7 +171,9 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
                 <LoadingSpinner size="sm" />
               </div>
             )}
-            {modal.error && <p className="text-sm text-red-600">{modal.error}</p>}
+            {modal.error && (
+              <p className="text-sm text-red-600">{modal.error}</p>
+            )}
             {modal.content && (
               <pre className="whitespace-pre-wrap text-sm text-zinc-700 leading-relaxed font-sans">
                 {modal.content}

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -35,6 +35,14 @@ function parseActions(raw: string): string[] {
   }
 }
 
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-zinc-400">
+      {children}
+    </p>
+  );
+}
+
 export default function EvidencePanel({
   clauseResult,
   analysisId,
@@ -51,8 +59,6 @@ export default function EvidencePanel({
     (clauseResult.overriddenRiskLevel as RiskLevel | null) ??
     clauseResult.riskLevel;
 
-  // evidenceSetId is included in the GET /risk-analyses/:id response via
-  // LEFT JOIN on evidence_sets (signsafe-api #16).
   const evidenceSetId = clauseResult.evidenceSetId;
 
   useEffect(() => {
@@ -72,7 +78,6 @@ export default function EvidencePanel({
     setRetrieving(true);
     try {
       await api.retrieveEvidence(evidenceSetId, 10);
-      // Re-fetch the evidence set after retrieve.
       const updated = await api.getEvidenceSet(evidenceSetId);
       setEvidenceSet(updated);
     } catch {
@@ -92,32 +97,35 @@ export default function EvidencePanel({
         initial={{ x: "100%" }}
         animate={{ x: 0 }}
         exit={{ x: "100%" }}
-        transition={{ type: "spring", stiffness: 300, damping: 30 }}
+        transition={{ type: "spring", stiffness: 320, damping: 32 }}
         className="flex w-96 flex-shrink-0 flex-col border-l border-zinc-200 bg-white"
         style={{ height: "100%" }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-zinc-100 px-4 py-3">
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between border-b border-zinc-100 px-4 py-3.5">
+          <div className="flex items-center gap-2 min-w-0">
             <RiskBadge
               level={effectiveLevel}
               overridden={!!clauseResult.overriddenRiskLevel}
             />
             {clauseResult.issueType && (
-              <span className="text-xs text-zinc-500">{clauseResult.issueType}</span>
+              <span className="truncate text-xs text-zinc-500">
+                {clauseResult.issueType}
+              </span>
             )}
           </div>
-          <div className="flex items-center gap-1">
+          <div className="flex flex-shrink-0 items-center gap-1">
             <button
               onClick={() => setShowOverride(true)}
-              className="rounded px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-100"
+              className="rounded-md px-2.5 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
               title="Override risk level"
             >
               Override
             </button>
             <button
               onClick={onClose}
-              className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700"
+              className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+              aria-label="Close panel"
             >
               <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -129,35 +137,39 @@ export default function EvidencePanel({
         <div className="flex flex-1 flex-col overflow-y-auto">
           {/* Summary */}
           {clauseResult.summary && (
-            <div className="border-b border-zinc-100 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1">
-                Summary
-              </p>
+            <div className="border-b border-zinc-100 px-4 py-4">
+              <SectionLabel>Summary</SectionLabel>
               <p className="text-sm text-zinc-700 leading-relaxed">
                 {clauseResult.summary}
               </p>
             </div>
           )}
 
-          {/* Evidence */}
-          <div className="flex-1 px-4 py-3 space-y-4">
+          {/* Evidence body */}
+          <div className="flex-1 px-4 py-4 space-y-5">
             {!evidenceSetId ? (
-              <p className="text-sm text-zinc-400">
-                No evidence data available for this clause.
-              </p>
+              <div className="flex flex-col items-center justify-center py-10 text-center">
+                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-zinc-100">
+                  <svg className="h-5 w-5 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                </div>
+                <p className="text-sm text-zinc-400">No evidence data available.</p>
+              </div>
             ) : loadState === "loading" ? (
-              <div className="flex justify-center py-8">
+              <div className="flex justify-center py-10">
                 <LoadingSpinner size="sm" />
               </div>
             ) : loadState === "error" ? (
-              <p className="text-sm text-red-500">Failed to load evidence.</p>
+              <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+                Failed to load evidence.
+              </div>
             ) : evidenceSet ? (
               <>
                 {/* Rationale */}
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1">
-                    Rationale
-                  </p>
+                  <SectionLabel>Rationale</SectionLabel>
                   <p className="text-sm text-zinc-700 leading-relaxed">
                     {evidenceSet.rationale}
                   </p>
@@ -166,9 +178,9 @@ export default function EvidencePanel({
                 {/* Citations */}
                 {citations.length > 0 && (
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+                    <SectionLabel>
                       Supporting evidence ({citations.length})
-                    </p>
+                    </SectionLabel>
                     <div className="space-y-2">
                       {citations.map((citation) => (
                         <CitationCard
@@ -181,9 +193,16 @@ export default function EvidencePanel({
                     <button
                       onClick={handleRetrieveMore}
                       disabled={retrieving}
-                      className="mt-3 text-xs text-zinc-500 hover:text-zinc-900 hover:underline disabled:opacity-50"
+                      className="mt-3 flex items-center gap-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50"
                     >
-                      {retrieving ? "Loading more…" : "Load more evidence"}
+                      {retrieving ? (
+                        <>
+                          <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-500" />
+                          Loading more…
+                        </>
+                      ) : (
+                        "Load more evidence"
+                      )}
                     </button>
                   </div>
                 )}
@@ -191,14 +210,14 @@ export default function EvidencePanel({
                 {/* Recommended actions */}
                 {actions.length > 0 && (
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
-                      Recommended actions
-                    </p>
-                    <ul className="space-y-1.5">
+                    <SectionLabel>Recommended actions</SectionLabel>
+                    <ul className="space-y-2">
                       {actions.map((action, i) => (
-                        <li key={i} className="flex items-start gap-2 text-sm text-zinc-700">
-                          <span className="mt-0.5 flex-shrink-0 h-4 w-4 rounded border border-zinc-300" />
-                          {action}
+                        <li key={i} className="flex items-start gap-2.5 text-sm text-zinc-700">
+                          <span className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border border-zinc-300 bg-white text-[10px] font-semibold text-zinc-400">
+                            {i + 1}
+                          </span>
+                          <span className="leading-relaxed">{action}</span>
                         </li>
                       ))}
                     </ul>

--- a/src/components/risk/OverrideDialog.tsx
+++ b/src/components/risk/OverrideDialog.tsx
@@ -15,6 +15,13 @@ interface OverrideDialogProps {
 
 const RISK_LEVELS: RiskLevel[] = ["HIGH", "MEDIUM", "LOW"];
 
+const LEVEL_STYLES: Record<RiskLevel, string> = {
+  HIGH: "border-red-200 text-red-700 data-[selected]:border-red-600 data-[selected]:bg-red-600 data-[selected]:text-white",
+  MEDIUM: "border-amber-200 text-amber-700 data-[selected]:border-amber-500 data-[selected]:bg-amber-500 data-[selected]:text-white",
+  LOW: "border-green-200 text-green-700 data-[selected]:border-green-600 data-[selected]:bg-green-600 data-[selected]:text-white",
+  none: "border-zinc-200 text-zinc-600",
+};
+
 export default function OverrideDialog({
   clauseResult,
   analysisId,
@@ -69,21 +76,29 @@ export default function OverrideDialog({
 
   return (
     <Modal onClose={onClose}>
-      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
-        <div className="mb-4 flex items-center justify-between">
+      <div className="w-full max-w-md animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
+        {/* Header */}
+        <div className="mb-5 flex items-center justify-between">
           <h3 className="text-base font-semibold text-zinc-900">Override risk level</h3>
-          <button onClick={onClose} className="text-zinc-400 hover:text-zinc-700">
-            ✕
+          <button
+            onClick={onClose}
+            className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+            aria-label="Close"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
           </button>
         </div>
 
-        <p className="mb-4 text-sm text-zinc-500">
-          Current assessment: <RiskBadge level={currentLevel} className="ml-1" />
+        <p className="mb-5 flex items-center gap-2 text-sm text-zinc-500">
+          Current assessment:
+          <RiskBadge level={currentLevel} />
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700">
+            <label className="mb-2.5 block text-sm font-medium text-zinc-700">
               New risk level
             </label>
             <div className="flex gap-2">
@@ -92,11 +107,16 @@ export default function OverrideDialog({
                   key={level}
                   type="button"
                   onClick={() => setNewLevel(level)}
+                  data-selected={newLevel === level ? true : undefined}
                   className={[
-                    "flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors",
+                    "flex-1 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors",
                     newLevel === level
-                      ? "border-zinc-800 bg-zinc-900 text-white"
-                      : "border-zinc-300 text-zinc-600 hover:border-zinc-500",
+                      ? level === "HIGH"
+                        ? "border-red-600 bg-red-600 text-white"
+                        : level === "MEDIUM"
+                        ? "border-amber-500 bg-amber-500 text-white"
+                        : "border-green-600 bg-green-600 text-white"
+                      : LEVEL_STYLES[level],
                   ].join(" ")}
                 >
                   {level}
@@ -108,7 +128,7 @@ export default function OverrideDialog({
           <div>
             <label
               htmlFor="override-reason"
-              className="mb-1 block text-sm font-medium text-zinc-700"
+              className="mb-1.5 block text-sm font-medium text-zinc-700"
             >
               Reason <span className="text-red-500">*</span>
             </label>
@@ -119,26 +139,37 @@ export default function OverrideDialog({
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               placeholder="Explain why the AI assessment should be overridden…"
-              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+              className="w-full resize-none rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
             />
           </div>
 
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3.5 py-2.5 text-sm text-red-600">
+              {error}
+            </div>
+          )}
 
           <div className="flex gap-2 pt-1">
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
+              className="flex-1 rounded-lg border border-zinc-200 px-4 py-2.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={submitting}
-              className="flex-1 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+              className="flex-1 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50"
             >
-              {submitting ? "Saving…" : "Save override"}
+              {submitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+                  Saving…
+                </span>
+              ) : (
+                "Save override"
+              )}
             </button>
           </div>
         </form>

--- a/src/components/risk/RiskBadge.tsx
+++ b/src/components/risk/RiskBadge.tsx
@@ -7,17 +7,24 @@ interface RiskBadgeProps {
 }
 
 const STYLES: Record<RiskLevel, string> = {
-  HIGH: "bg-red-100 text-red-700 ring-red-200",
-  MEDIUM: "bg-orange-100 text-orange-700 ring-orange-200",
-  LOW: "bg-green-100 text-green-700 ring-green-200",
-  none: "bg-zinc-100 text-zinc-500 ring-zinc-200",
+  HIGH:   "bg-red-50 text-red-700 ring-red-200",
+  MEDIUM: "bg-amber-50 text-amber-700 ring-amber-200",
+  LOW:    "bg-green-50 text-green-700 ring-green-200",
+  none:   "bg-zinc-100 text-zinc-500 ring-zinc-200",
 };
 
 const LABELS: Record<RiskLevel, string> = {
-  HIGH: "High Risk",
-  MEDIUM: "Medium Risk",
-  LOW: "Low Risk",
-  none: "Not Analyzed",
+  HIGH:   "High",
+  MEDIUM: "Medium",
+  LOW:    "Low",
+  none:   "—",
+};
+
+const DOT_COLORS: Record<RiskLevel, string> = {
+  HIGH:   "bg-red-500",
+  MEDIUM: "bg-amber-500",
+  LOW:    "bg-green-500",
+  none:   "bg-zinc-400",
 };
 
 export default function RiskBadge({
@@ -27,14 +34,15 @@ export default function RiskBadge({
 }: RiskBadgeProps) {
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${
         STYLES[level] ?? STYLES.none
       } ${className}`}
     >
+      <span className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${DOT_COLORS[level] ?? DOT_COLORS.none}`} />
       {LABELS[level] ?? level}
       {overridden && (
-        <span className="ml-0.5 rounded bg-current/20 px-1 text-[10px] opacity-70">
-          overridden
+        <span className="rounded px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide opacity-60 bg-current/10">
+          edited
         </span>
       )}
     </span>

--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -45,8 +45,8 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
 
   return (
     <Modal onClose={onClose}>
-      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
-        <h2 className="mb-4 text-base font-semibold text-zinc-900">New Organization</h2>
+      <div className="w-full max-w-sm animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
+        <h2 className="mb-5 text-base font-semibold text-zinc-900">New Organization</h2>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
             <label htmlFor="org-name" className="text-sm font-medium text-zinc-700">
@@ -60,26 +60,35 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
               onChange={(e) => setName(e.target.value)}
               placeholder="Acme Corp"
               maxLength={100}
-              className="rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-400 disabled:opacity-50"
+              className="rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10 disabled:opacity-50"
               disabled={status === "loading"}
             />
-            {errorMsg && <p className="text-xs text-red-600">{errorMsg}</p>}
+            {errorMsg && (
+              <p className="text-xs text-red-600">{errorMsg}</p>
+            )}
           </div>
 
           <div className="flex justify-end gap-2">
             <button
               type="button"
               onClick={onClose}
-              className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-50"
+              className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-50"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={status === "loading" || name.trim().length === 0}
-              className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50"
+              className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50"
             >
-              {status === "loading" ? "Creating..." : "Create"}
+              {status === "loading" ? (
+                <span className="flex items-center gap-2">
+                  <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+                  Creating…
+                </span>
+              ) : (
+                "Create"
+              )}
             </button>
           </div>
         </form>
@@ -154,13 +163,18 @@ export function OrgSwitcher() {
       <div ref={dropdownRef} className="relative hidden sm:block">
         <button
           onClick={handleOpen}
-          className="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-600 border border-zinc-200 hover:bg-zinc-200 transition-colors"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-100"
           aria-haspopup="listbox"
           aria-expanded={open}
         >
-          {currentOrgName}
+          {/* Building icon */}
+          <svg className="h-3.5 w-3.5 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+          </svg>
+          <span className="max-w-[120px] truncate">{currentOrgName}</span>
           <svg
-            className={`h-3 w-3 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
+            className={`h-3 w-3 text-zinc-400 transition-transform duration-150 ${open ? "rotate-180" : ""}`}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -172,16 +186,19 @@ export function OrgSwitcher() {
         {open && (
           <div
             role="listbox"
-            className="absolute left-0 top-full mt-1.5 w-56 rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
+            className="absolute left-0 top-full mt-1.5 w-60 animate-slide-in rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
           >
             {loadStatus === "loading" && (
-              <p className="px-3 py-2 text-xs text-zinc-400">Loading...</p>
+              <div className="flex items-center gap-2 px-3 py-2.5">
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />
+                <span className="text-xs text-zinc-400">Loading…</span>
+              </div>
             )}
             {loadStatus === "error" && (
-              <p className="px-3 py-2 text-xs text-red-500">Failed to load organizations</p>
+              <p className="px-3 py-2.5 text-xs text-red-500">Failed to load organizations</p>
             )}
             {loadStatus === "idle" && orgs.length === 0 && (
-              <p className="px-3 py-2 text-xs text-zinc-400">No organizations found</p>
+              <p className="px-3 py-2.5 text-xs text-zinc-400">No organizations found</p>
             )}
             {loadStatus === "idle" &&
               orgs.map((org) => {
@@ -192,17 +209,22 @@ export function OrgSwitcher() {
                     role="option"
                     aria-selected={isActive}
                     onClick={() => handleSelect(org)}
-                    className="flex w-full items-center justify-between px-3 py-2 text-sm text-zinc-700 hover:bg-zinc-50"
+                    className="flex w-full items-center justify-between px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-50"
                   >
-                    <span className="truncate">{org.name}</span>
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-zinc-100 text-xs font-semibold text-zinc-600 uppercase">
+                        {org.name.charAt(0)}
+                      </div>
+                      <span className="truncate">{org.name}</span>
+                    </div>
                     {isActive && (
                       <svg
-                        className="ml-2 h-4 w-4 flex-shrink-0 text-zinc-900"
+                        className="ml-2 h-3.5 w-3.5 flex-shrink-0 text-zinc-900"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
                       >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
                       </svg>
                     )}
                   </button>
@@ -213,9 +235,9 @@ export function OrgSwitcher() {
               <Link
                 href="/settings/organization"
                 onClick={() => setOpen(false)}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-600 hover:bg-zinc-50"
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-zinc-600 transition-colors hover:bg-zinc-50"
               >
-                <svg className="h-4 w-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="h-4 w-4 flex-shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                     d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -227,9 +249,9 @@ export function OrgSwitcher() {
                   setOpen(false);
                   setShowModal(true);
                 }}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-600 hover:bg-zinc-50"
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-zinc-600 transition-colors hover:bg-zinc-50"
               >
-                <svg className="h-4 w-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="h-4 w-4 flex-shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
                 New organization

--- a/src/components/ui/SettingsUI.tsx
+++ b/src/components/ui/SettingsUI.tsx
@@ -2,8 +2,6 @@
 
 /**
  * Shared UI primitives used by settings pages.
- * Extracted to avoid duplication between settings/page.tsx and
- * settings/organization/page.tsx.
  */
 
 // ── Role badge ────────────────────────────────────────────────────────────────
@@ -14,12 +12,12 @@ interface RoleBadgeProps {
 
 const ROLE_BADGE_VARIANTS: Record<string, string> = {
   admin: "bg-zinc-900 text-white",
-  reviewer: "bg-blue-50 text-blue-700",
-  member: "bg-zinc-100 text-zinc-700",
+  reviewer: "bg-blue-50 text-blue-700 ring-1 ring-blue-200",
+  member: "bg-zinc-100 text-zinc-600",
 };
 
 export function RoleBadge({ role }: RoleBadgeProps) {
-  const cls = ROLE_BADGE_VARIANTS[role] ?? "bg-zinc-100 text-zinc-700";
+  const cls = ROLE_BADGE_VARIANTS[role] ?? "bg-zinc-100 text-zinc-600";
   return (
     <span
       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${cls}`}
@@ -38,7 +36,7 @@ interface SpinnerProps {
 export function Spinner({ className = "" }: SpinnerProps) {
   return (
     <div
-      className={`animate-spin rounded-full border border-white/40 border-t-white ${className}`}
+      className={`animate-spin rounded-full border border-white/30 border-t-white ${className}`}
     />
   );
 }
@@ -53,14 +51,14 @@ interface SectionProps {
 
 export function Section({ title, description, children }: SectionProps) {
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white shadow-sm">
-      <div className="border-b border-zinc-100 px-6 py-4">
+    <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
+      <div className="border-b border-zinc-100 px-6 py-5">
         <h2 className="text-sm font-semibold text-zinc-900">{title}</h2>
         {description && (
           <p className="mt-0.5 text-sm text-zinc-500">{description}</p>
         )}
       </div>
-      <div className="px-6 py-5">{children}</div>
+      <div className="px-6 py-6">{children}</div>
     </div>
   );
 }
@@ -84,7 +82,7 @@ export function Field({ label, children }: FieldProps) {
 // ── Shared class strings ──────────────────────────────────────────────────────
 
 export const inputCls =
-  "w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900 disabled:opacity-50 disabled:bg-zinc-50";
+  "w-full rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10 disabled:opacity-50 disabled:bg-zinc-50";
 
 export const primaryBtnCls =
-  "flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 transition-colors";
+  "inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50";

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -40,7 +40,8 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={{ toast }}>
       {children}
-      <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none">
+      {/* Toast container — bottom-right, stacked */}
+      <div className="fixed bottom-5 right-5 z-[100] flex flex-col-reverse gap-2 pointer-events-none">
         {toasts.map((t) => (
           <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
         ))}
@@ -66,41 +67,59 @@ function ToastItem({
   }, [toast.id, onDismiss]);
 
   const base =
-    "pointer-events-auto flex items-start gap-3 rounded-lg px-4 py-3 shadow-lg text-sm font-medium max-w-sm w-full animate-slide-in";
+    "pointer-events-auto flex items-start gap-3 rounded-xl border px-4 py-3 shadow-md text-sm max-w-[360px] w-full animate-slide-in";
 
   const styles: Record<ToastType, string> = {
-    success: `${base} bg-green-50 text-green-800 ring-1 ring-green-200`,
-    error: `${base} bg-red-50 text-red-800 ring-1 ring-red-200`,
-    info: `${base} bg-zinc-900 text-white`,
+    success: `${base} bg-white border-zinc-200 text-zinc-800`,
+    error:   `${base} bg-white border-zinc-200 text-zinc-800`,
+    info:    `${base} bg-zinc-900 border-zinc-800 text-white`,
+  };
+
+  const iconWrappers: Record<ToastType, string> = {
+    success: "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-green-100",
+    error:   "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-red-100",
+    info:    "flex h-5 w-5 flex-shrink-0 items-center justify-center",
   };
 
   const icons: Record<ToastType, React.ReactNode> = {
     success: (
-      <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-      </svg>
+      <div className={iconWrappers.success}>
+        <svg className="h-3 w-3 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
     ),
     error: (
-      <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-      </svg>
+      <div className={iconWrappers.error}>
+        <svg className="h-3 w-3 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </div>
     ),
     info: (
-      <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-zinc-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-      </svg>
+      <div className={iconWrappers.info}>
+        <svg className="h-4 w-4 text-zinc-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
     ),
   };
+
+  const closeCls =
+    toast.type === "info"
+      ? "ml-auto flex-shrink-0 text-zinc-400 transition-colors hover:text-zinc-200"
+      : "ml-auto flex-shrink-0 text-zinc-300 transition-colors hover:text-zinc-500";
 
   return (
     <div className={styles[toast.type]}>
       {icons[toast.type]}
-      <span className="flex-1 leading-5">{toast.message}</span>
+      <span className="flex-1 leading-5 font-medium">{toast.message}</span>
       <button
         onClick={() => onDismiss(toast.id)}
-        className="ml-auto flex-shrink-0 opacity-50 hover:opacity-100 transition-opacity"
+        className={closeCls}
+        aria-label="Dismiss"
       >
-        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>

--- a/src/components/ui/primitives.tsx
+++ b/src/components/ui/primitives.tsx
@@ -2,7 +2,6 @@
 
 /**
  * Minimal shared UI primitives used across the app.
- * Each export is kept intentionally small — no prop-drilling or complex APIs.
  */
 
 // ── Loading Spinner ────────────────────────────────────────────────────────────
@@ -21,7 +20,7 @@ const SPINNER_SIZE: Record<NonNullable<LoadingSpinnerProps["size"]>, string> = {
 export function LoadingSpinner({ size = "md", className = "" }: LoadingSpinnerProps) {
   return (
     <div
-      className={`animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700 ${SPINNER_SIZE[size]} ${className}`}
+      className={`animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-600 ${SPINNER_SIZE[size]} ${className}`}
     />
   );
 }
@@ -40,7 +39,7 @@ interface ModalProps {
 export function Modal({ onClose, children }: ModalProps) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4 backdrop-blur-[2px] animate-fade-in"
       onClick={onClose}
     >
       <div onClick={(e) => e.stopPropagation()}>{children}</div>

--- a/src/components/upload/DropZone.tsx
+++ b/src/components/upload/DropZone.tsx
@@ -14,7 +14,7 @@ export default function DropZone({ onFile, disabled = false }: DropZoneProps) {
   function validateAndEmit(file: File) {
     setError(null);
     if (file.type !== "application/pdf" && !file.name.toLowerCase().endsWith(".pdf")) {
-      setError("PDF 파일만 업로드할 수 있습니다.");
+      setError("Only PDF files are supported.");
       return;
     }
     if (file.size > 50 * 1024 * 1024) {
@@ -24,10 +24,13 @@ export default function DropZone({ onFile, disabled = false }: DropZoneProps) {
     onFile(file);
   }
 
-  const onDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    if (!disabled) setDragging(true);
-  }, [disabled]);
+  const onDragOver = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      if (!disabled) setDragging(true);
+    },
+    [disabled]
+  );
 
   const onDragLeave = useCallback(() => {
     setDragging(false);
@@ -41,17 +44,16 @@ export default function DropZone({ onFile, disabled = false }: DropZoneProps) {
       const file = e.dataTransfer.files[0];
       if (file) validateAndEmit(file);
     },
-    [disabled]  // eslint-disable-line react-hooks/exhaustive-deps
+    [disabled] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const onInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
       if (file) validateAndEmit(file);
-      // Reset input so same file can be re-selected.
       e.target.value = "";
     },
-    []  // eslint-disable-line react-hooks/exhaustive-deps
+    [] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return (
@@ -62,31 +64,39 @@ export default function DropZone({ onFile, disabled = false }: DropZoneProps) {
         onDragLeave={onDragLeave}
         onDrop={onDrop}
         className={[
-          "flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed px-6 py-12 transition-colors",
+          "flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed px-6 py-10 text-center transition-colors",
           dragging
-            ? "border-zinc-600 bg-zinc-100"
-            : "border-zinc-300 bg-white hover:border-zinc-400",
+            ? "border-zinc-500 bg-zinc-100"
+            : "border-zinc-200 bg-zinc-50 hover:border-zinc-400 hover:bg-zinc-100",
           disabled ? "cursor-not-allowed opacity-50" : "",
         ].join(" ")}
       >
-        <svg
-          className="mb-3 h-10 w-10 text-zinc-400"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-          />
-        </svg>
+        {/* Upload icon */}
+        <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-white ring-1 ring-zinc-200 shadow-sm">
+          <svg
+            className="h-5 w-5 text-zinc-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+            />
+          </svg>
+        </div>
         <p className="text-sm font-medium text-zinc-700">
-          Drag &amp; drop your contract here, or{" "}
-          <span className="text-zinc-900 underline underline-offset-2">browse</span>
+          Drag &amp; drop your PDF here
         </p>
-        <p className="mt-1 text-xs text-zinc-400">PDF — max 50 MB</p>
+        <p className="mt-1 text-xs text-zinc-400">
+          or{" "}
+          <span className="font-medium text-zinc-600 underline underline-offset-2">
+            browse to upload
+          </span>
+        </p>
+        <p className="mt-2 text-xs text-zinc-300">PDF only — max 50 MB</p>
         <input
           id="contract-file-input"
           type="file"
@@ -98,7 +108,13 @@ export default function DropZone({ onFile, disabled = false }: DropZoneProps) {
       </label>
 
       {error && (
-        <p className="text-sm text-red-600">{error}</p>
+        <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3.5 py-2.5 text-sm text-red-600">
+          <svg className="h-4 w-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {error}
+        </div>
       )}
     </div>
   );

--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -11,12 +11,12 @@ interface IngestionProgressProps {
 }
 
 const STEP_LABELS: Record<string, string> = {
-  pending: "Queued",
-  parsing: "Parsing document…",
-  chunking: "Splitting into clauses…",
-  indexing: "Building search index…",
+  pending:   "Queued",
+  parsing:   "Parsing document…",
+  chunking:  "Splitting into clauses…",
+  indexing:  "Building search index…",
   completed: "Complete",
-  failed: "Failed",
+  failed:    "Failed",
 };
 
 export default function IngestionProgress({
@@ -25,13 +25,10 @@ export default function IngestionProgress({
   onError,
 }: IngestionProgressProps) {
   const [job, setJob] = useState<IngestionJob | null>(null);
-  // Use a ref so the async poll callback always reads the latest timerId value.
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  // Store callbacks in refs so the polling closure always invokes the latest
-  // version without requiring a dep-driven effect restart.
   const onCompleteRef = useRef(onComplete);
   const onErrorRef = useRef(onError);
+
   useEffect(() => {
     onCompleteRef.current = onComplete;
     onErrorRef.current = onError;
@@ -43,7 +40,7 @@ export default function IngestionProgress({
     async function poll() {
       try {
         const j = await api.getIngestionJob(jobId);
-        if (stopped) return; // component unmounted while request was in flight
+        if (stopped) return;
         setJob(j);
         if (j.status === "completed" || j.status === "failed") {
           if (timerRef.current) {
@@ -61,7 +58,7 @@ export default function IngestionProgress({
       }
     }
 
-    poll(); // immediate first poll
+    poll();
     timerRef.current = setInterval(poll, 1500);
 
     return () => {
@@ -74,11 +71,9 @@ export default function IngestionProgress({
   }, [jobId]);
 
   if (!job) {
-    // File upload is already done at this point — we are waiting for the first
-    // ingestion job poll to return. "Uploading…" is therefore misleading.
     return (
-      <div className="flex items-center gap-2 text-sm text-zinc-500">
-        <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600" />
+      <div className="flex items-center gap-2 text-xs text-zinc-500">
+        <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />
         <span>Processing…</span>
       </div>
     );
@@ -86,25 +81,41 @@ export default function IngestionProgress({
 
   const progress = job.progress ?? 0;
   const label = STEP_LABELS[job.status] ?? job.status;
-
   const isFailed = job.status === "failed";
   const isComplete = job.status === "completed";
 
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2">
       <div className="flex items-center justify-between text-xs text-zinc-500">
-        <span>{label}</span>
-        <span>{progress}%</span>
+        <span className="flex items-center gap-1.5">
+          {!isFailed && !isComplete && (
+            <span className="h-2.5 w-2.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />
+          )}
+          {isComplete && (
+            <svg className="h-3 w-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+          )}
+          {isFailed && (
+            <svg className="h-3 w-3 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          )}
+          {label}
+        </span>
+        <span className="font-medium tabular-nums">{progress}%</span>
       </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-200">
+
+      <div className="h-1 w-full overflow-hidden rounded-full bg-zinc-100">
         <div
           className={[
             "h-full rounded-full transition-all duration-300",
-            isFailed ? "bg-red-500" : isComplete ? "bg-green-500" : "bg-zinc-700",
+            isFailed ? "bg-red-500" : isComplete ? "bg-green-500" : "bg-zinc-600",
           ].join(" ")}
           style={{ width: `${progress}%` }}
         />
       </div>
+
       {isFailed && job.errorMessage && (
         <p className="text-xs text-red-600">{job.errorMessage}</p>
       )}

--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -10,10 +10,16 @@ interface ClauseNavProps {
   onClauseSelect: (clause: Clause) => void;
 }
 
-/** Build a lookup from clauseId → ClauseResult */
 function buildResultMap(results: ClauseResult[]): Map<string, ClauseResult> {
   return new Map(results.map((r) => [r.clauseId, r]));
 }
+
+const RISK_INDICATOR: Record<RiskLevel, string> = {
+  HIGH: "bg-red-500",
+  MEDIUM: "bg-amber-500",
+  LOW: "bg-green-500",
+  none: "bg-zinc-300",
+};
 
 export default function ClauseNav({
   clauses,
@@ -22,13 +28,27 @@ export default function ClauseNav({
   onClauseSelect,
 }: ClauseNavProps) {
   const resultMap = buildResultMap(clauseResults);
+  const analyzedCount = clauseResults.length;
 
   return (
-    <nav className="flex flex-col overflow-y-auto">
-      <p className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-zinc-400">
-        Clauses ({clauses.length})
-      </p>
-      <ul className="space-y-0.5 px-2 pb-4">
+    <nav className="flex h-full flex-col">
+      {/* Header */}
+      <div className="border-b border-zinc-100 px-4 py-3.5">
+        <p className="text-xs font-semibold text-zinc-900">
+          Clauses
+          <span className="ml-1.5 font-normal text-zinc-400">
+            ({clauses.length})
+          </span>
+        </p>
+        {analyzedCount > 0 && (
+          <p className="mt-0.5 text-xs text-zinc-400">
+            {analyzedCount} analyzed
+          </p>
+        )}
+      </div>
+
+      {/* List */}
+      <ul className="flex-1 overflow-y-auto space-y-0.5 px-2 py-2">
         {clauses.map((clause) => {
           const result = resultMap.get(clause.id);
           const riskLevel: RiskLevel =
@@ -36,39 +56,58 @@ export default function ClauseNav({
             result?.riskLevel ??
             "none";
           const isSelected = clause.id === selectedClauseId;
+          const hasResult = !!result;
 
           return (
             <li key={clause.id}>
               <button
                 onClick={() => onClauseSelect(clause)}
                 className={[
-                  "w-full rounded-md px-3 py-2.5 text-left text-sm transition-colors",
+                  "group w-full rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
                   isSelected
                     ? "bg-zinc-900 text-white"
                     : "text-zinc-700 hover:bg-zinc-100",
                 ].join(" ")}
               >
-                <div className="flex items-start justify-between gap-2">
-                  <span className="flex-1 leading-snug line-clamp-2">
-                    {clause.label ?? `Clause ${clause.clauseIndex + 1}`}
-                  </span>
-                  {result && (
-                    <RiskBadge
-                      level={riskLevel}
-                      overridden={!!result.overriddenRiskLevel}
-                      className={isSelected ? "opacity-90" : ""}
+                <div className="flex items-start gap-2.5">
+                  {/* Risk indicator dot */}
+                  {hasResult && (
+                    <span
+                      className={[
+                        "mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full",
+                        isSelected ? "opacity-90" : "",
+                        RISK_INDICATOR[riskLevel],
+                      ].join(" ")}
                     />
                   )}
+                  {!hasResult && (
+                    <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-transparent" />
+                  )}
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2">
+                      <span className="flex-1 leading-snug line-clamp-2 text-xs font-medium">
+                        {clause.label ?? `Clause ${clause.clauseIndex + 1}`}
+                      </span>
+                      {result && (
+                        <RiskBadge
+                          level={riskLevel}
+                          overridden={!!result.overriddenRiskLevel}
+                          className={isSelected ? "opacity-90 flex-shrink-0" : "flex-shrink-0"}
+                        />
+                      )}
+                    </div>
+                    {clause.pageStart > 0 && (
+                      <span
+                        className={`mt-0.5 block text-xs ${
+                          isSelected ? "text-zinc-400" : "text-zinc-400"
+                        }`}
+                      >
+                        p. {clause.pageStart}
+                      </span>
+                    )}
+                  </div>
                 </div>
-                {clause.pageStart > 0 && (
-                  <span
-                    className={`mt-0.5 text-xs ${
-                      isSelected ? "text-zinc-300" : "text-zinc-400"
-                    }`}
-                  >
-                    Page {clause.pageStart}
-                  </span>
-                )}
               </button>
             </li>
           );


### PR DESCRIPTION
## 변경사항

- **globals.css**: 디자인 토큰, 커스텀 scrollbar, focus ring, `slide-in` / `fade-in` / `slide-in-right` 애니메이션
- **AppLayout**: 네비게이션 active underline indicator, shield 로고 아이콘, 버튼 hover 정제
- **인증 레이아웃**: 격자 배경 + shield 아이콘 브랜딩, 모든 카드 `rounded-2xl` 통일
- **인증 페이지** (login/signup/forgot-password/reset-password/verify-email): 버튼 `py-2.5 font-semibold`, 로딩 인라인 스피너, 에러 카드 `border + bg` 방식으로 통일
- **계약 목록**: 빈 상태 `dashed border` 카드 + CTA 버튼, 업로드 버튼 토글, 삭제 모달 inline spinner
- **계약 상세**: 툴바 breadcrumb 아이콘 개선, 분석 상태 badge, 에러 카드 UI
- **Toast**: 흰색 카드 + 색상 dot 아이콘, `flex-col-reverse` 스택
- **Modal**: `backdrop-blur` 추가, `animate-fade-in`
- **OrgSwitcher**: 빌딩 아이콘, org 이니셜 아바타, loading inline 스피너
- **ClauseNav**: 리스크 레벨 dot indicator, 헤더 영역 분리, 페이지 번호 `p.N` 형식
- **EvidencePanel**: `SectionLabel` 컴포넌트, 권장 조치 번호 아이콘, 빈 상태 일러스트
- **CitationCard**: emoji 제거 → SVG 아이콘, match score 배지
- **RiskBadge**: dot + 짧은 레이블(High/Medium/Low), overridden → `edited` 배지
- **OverrideDialog**: 레벨별 색상 버튼, 에러 카드 스타일
- **DropZone**: 아이콘 카드 박스, 에러 아이콘 포함 카드
- **IngestionProgress**: 완료/실패 SVG 아이콘, `tabular-nums` 퍼센트
- **EditContractModal**: 2-col grid(language/type), header close 버튼
- **loading/error** 스켈레톤 일관성 개선

## QA 결과

- `npm run build` 통과 (TypeScript strict, 0 errors)
- 26개 파일, +1147 / -588 lines

Closes #82