### PR TITLE
feat(#86): 모바일 OrgSwitcher 표시 및 Settings 탭 네비게이션

### DIFF
--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+function SettingsTab({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const isActive = pathname === href;
+
+  return (
+    <Link
+      href={href}
+      className={[
+        "relative pb-3 text-sm font-medium transition-colors duration-150",
+        isActive
+          ? "text-zinc-900"
+          : "text-zinc-500 hover:text-zinc-800",
+      ].join(" ")}
+    >
+      {children}
+      {isActive && (
+        <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-zinc-900" />
+      )}
+    </Link>
+  );
+}
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col">
+      {/* Sticky tab bar */}
+      <div className="sticky top-14 z-20 border-b border-zinc-200 bg-white">
+        <div className="mx-auto flex max-w-3xl gap-6 px-4 pt-5 sm:px-6">
+          <SettingsTab href="/settings">Account</SettingsTab>
+          <SettingsTab href="/settings/organization">Organization</SettingsTab>
+        </div>
+      </div>
+
+      {/* Page content — each page provides its own container */}
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -160,21 +160,25 @@ export function OrgSwitcher() {
 
   return (
     <>
-      <div ref={dropdownRef} className="relative hidden sm:block">
+      {/* Always visible — icon-only on mobile, icon+name on sm+ */}
+      <div ref={dropdownRef} className="relative">
         <button
           onClick={handleOpen}
-          className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-100"
+          className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-zinc-50 px-2 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-100 sm:px-2.5"
           aria-haspopup="listbox"
           aria-expanded={open}
+          title={currentOrgName}
         >
-          {/* Building icon */}
-          <svg className="h-3.5 w-3.5 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          {/* Building icon — always visible */}
+          <svg className="h-3.5 w-3.5 flex-shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
               d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
           </svg>
-          <span className="max-w-[120px] truncate">{currentOrgName}</span>
+          {/* Org name — hidden on mobile, visible on sm+ */}
+          <span className="hidden max-w-[120px] truncate sm:inline">{currentOrgName}</span>
+          {/* Chevron — hidden on mobile */}
           <svg
-            className={`h-3 w-3 text-zinc-400 transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+            className={`hidden h-3 w-3 text-zinc-400 transition-transform duration-150 sm:block ${open ? "rotate-180" : ""}`}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -186,7 +190,7 @@ export function OrgSwitcher() {
         {open && (
           <div
             role="listbox"
-            className="absolute left-0 top-full mt-1.5 w-60 animate-slide-in rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
+            className="absolute right-0 top-full mt-1.5 w-60 animate-slide-in rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
           >
             {loadStatus === "loading" && (
               <div className="flex items-center gap-2 px-3 py-2.5">


### PR DESCRIPTION
## 변경사항

- **OrgSwitcher 모바일 지원**: `hidden sm:block` 제거 → 모바일(xs)에서 building 아이콘으로 드롭다운 진입 가능. 조직명/chevron은 `sm:` 이상에서만 표시
- **드롭다운 정렬**: `left-0` → `right-0` 으로 변경해 좁은 화면에서 오버플로우 방지
- **Settings 탭 레이아웃**: `src/app/(app)/settings/layout.tsx` 신규 추가. Account / Organization 탭이 현재 경로에 따라 강조되며, sticky 배치로 스크롤 중에도 탭 접근 가능

## QA 결과

- TypeScript `tsc --noEmit` 통과
- 모바일(375px): 헤더에 building 아이콘 표시, 클릭 시 드롭다운 동작
- 데스크톱(1280px): 기존과 동일하게 조직명 + chevron 표시
- `/settings` 진입 시 Account 탭 강조, `/settings/organization` 진입 시 Organization 탭 강조

Closes #86