### PR TITLE
feat(#87): 계약 목록 검색 및 상태 필터

### DIFF
--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
-import type { Contract, IngestionJob } from "@/types";
+import type { Contract, ContractStatus, IngestionJob } from "@/types";
 import DropZone from "@/components/upload/DropZone";
 import IngestionProgress from "@/components/upload/IngestionProgress";
 import { useToast } from "@/components/ui/Toast";
@@ -37,6 +37,8 @@ const STATUS_COLOR: Record<string, string> = {
   ready: "bg-green-50 text-green-700 ring-green-200",
   failed: "bg-red-50 text-red-600 ring-red-200",
 };
+
+const STATUS_OPTIONS: ContractStatus[] = ["uploaded", "processing", "ready", "failed"];
 
 const PAGE_SIZE = 20;
 
@@ -80,6 +82,29 @@ export default function ContractsPage() {
     contractTitle: "",
   });
   const [deleting, setDeleting] = useState(false);
+
+  // Search & filter state
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<ContractStatus | "">("");
+
+  // Derived filtered list (client-side)
+  const filteredContracts = useMemo(() => {
+    let result = contracts;
+    if (searchQuery.trim()) {
+      const q = searchQuery.trim().toLowerCase();
+      result = result.filter(
+        (c) =>
+          c.title.toLowerCase().includes(q) ||
+          c.fileName.toLowerCase().includes(q)
+      );
+    }
+    if (statusFilter) {
+      result = result.filter((c) => c.status === statusFilter);
+    }
+    return result;
+  }, [contracts, searchQuery, statusFilter]);
+
+  const hasActiveFilters = searchQuery.trim() !== "" || statusFilter !== "";
 
   const fetchContracts = useCallback(async () => {
     if (!orgId) return;
@@ -168,6 +193,11 @@ export default function ContractsPage() {
     } finally {
       setDeleting(false);
     }
+  }
+
+  function clearFilters() {
+    setSearchQuery("");
+    setStatusFilter("");
   }
 
   return (
@@ -272,6 +302,71 @@ export default function ContractsPage() {
         </div>
       )}
 
+      {/* Search & filter bar (shown when contracts exist) */}
+      {loadState === "success" && contracts.length > 0 && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          {/* Search input */}
+          <div className="relative flex-1">
+            <svg
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search by title or filename…"
+              className="w-full rounded-lg border border-zinc-200 bg-white py-2 pl-9 pr-3.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-zinc-400 hover:text-zinc-600"
+                aria-label="Clear search"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
+
+          {/* Status filter */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as ContractStatus | "")}
+              className="rounded-lg border border-zinc-200 bg-white py-2 pl-3 pr-8 text-sm text-zinc-700 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
+            >
+              <option value="">All statuses</option>
+              {STATUS_OPTIONS.map((s) => (
+                <option key={s} value={s}>
+                  {STATUS_LABEL[s]}
+                </option>
+              ))}
+            </select>
+
+            {hasActiveFilters && (
+              <button
+                onClick={clearFilters}
+                className="cursor-pointer rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-700 whitespace-nowrap"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Loading */}
       {loadState === "loading" && (
         <div className="flex items-center justify-center py-24">
@@ -292,7 +387,7 @@ export default function ContractsPage() {
         </div>
       )}
 
-      {/* Empty state */}
+      {/* Empty state — no contracts at all */}
       {loadState === "success" && contracts.length === 0 && (
         <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-200 bg-white py-20 text-center">
           <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-zinc-100">
@@ -321,10 +416,30 @@ export default function ContractsPage() {
         </div>
       )}
 
+      {/* Empty state — filter returned no results */}
+      {loadState === "success" && contracts.length > 0 && filteredContracts.length === 0 && (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-200 bg-white py-16 text-center">
+          <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-zinc-100">
+            <svg className="h-5 w-5 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </div>
+          <p className="text-sm font-medium text-zinc-700">No contracts match your filters</p>
+          <p className="mt-1 text-sm text-zinc-400">Try adjusting your search or status filter.</p>
+          <button
+            onClick={clearFilters}
+            className="cursor-pointer mt-4 text-sm font-medium text-zinc-700 underline underline-offset-2 hover:no-underline"
+          >
+            Clear filters
+          </button>
+        </div>
+      )}
+
       {/* Contract list */}
-      {loadState === "success" && contracts.length > 0 && (
+      {loadState === "success" && filteredContracts.length > 0 && (
         <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
-          {contracts.map((c, i) => (
+          {filteredContracts.map((c, i) => (
             <div
               key={c.id}
               className={[
@@ -401,8 +516,8 @@ export default function ContractsPage() {
         </div>
       )}
 
-      {/* Load more */}
-      {loadState === "success" && contracts.length < total && (
+      {/* Load more — only when not filtered (server has more pages) */}
+      {loadState === "success" && !hasActiveFilters && contracts.length < total && (
         <div className="flex justify-center">
           <button
             onClick={loadMore}


### PR DESCRIPTION
## 변경사항

- **검색 입력**: 제목/파일명 기준 실시간 클라이언트 사이드 필터. 돋보기 아이콘 내장, 입력 시 X 버튼으로 빠른 초기화
- **상태 필터**: select 드롭다운으로 All / Uploaded / Processing / Ready / Failed 선택
- **Clear 버튼**: 검색 또는 상태 필터 활성 시 표시되어 한 번에 초기화
- **필터 빈 상태**: 검색 결과 없을 때 전용 메시지 + Clear filters 링크
- **Load more**: 필터 비활성 상태일 때만 표시 (필터 중 서버 추가 로드 불필요)

## QA 결과

- TypeScript `tsc --noEmit` 통과
- 계약 없을 때: 기존 빈 상태 그대로
- 계약 있을 때: 검색바 + 필터 드롭다운 표시
- 검색어 입력 → 즉시 필터링, X 버튼으로 초기화
- 필터 드롭다운 → 상태별 필터, Clear 버튼 노출

Closes #87