### PR TITLE
feat(#101): 계약 목록 만료일 임박/만료 배지 추가

### DIFF
--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -10,7 +10,7 @@ import DropZone from "@/components/upload/DropZone";
 import IngestionProgress from "@/components/upload/IngestionProgress";
 import { useToast } from "@/components/ui/Toast";
 import { Modal, LoadingSpinner } from "@/components/ui/primitives";
-import { getErrorMessage, formatBytes, formatDate } from "@/lib/utils";
+import { getErrorMessage, formatBytes, formatDate, getExpiryStatus } from "@/lib/utils";
 
 interface DeleteDialogState {
   open: boolean;
@@ -488,6 +488,23 @@ export default function ContractsPage() {
                     ) : null}
                   </div>
                 </div>
+
+                {/* Expiry badge */}
+                {(() => {
+                  const expiryStatus = getExpiryStatus(c.expiresAt);
+                  if (!expiryStatus) return null;
+                  return (
+                    <span
+                      className={
+                        expiryStatus === "expired"
+                          ? "flex-shrink-0 hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 bg-red-50 text-red-600 ring-red-200"
+                          : "flex-shrink-0 hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 bg-orange-50 text-orange-600 ring-orange-200"
+                      }
+                    >
+                      {expiryStatus === "expired" ? "Expired" : "Expires soon"}
+                    </span>
+                  );
+                })()}
 
                 {/* Status badge */}
                 <span

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,3 +31,26 @@ export function formatBytes(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
+
+/**
+ * Determine the expiry status of a contract given its expiresAt ISO string.
+ *
+ * Returns:
+ *  - "expired"      — expiresAt is in the past
+ *  - "expiring-soon"— expiresAt is within the next `withinDays` days (default 7)
+ *  - null           — not expired or not expiring soon (or no date provided)
+ */
+export function getExpiryStatus(
+  expiresAt: string | null | undefined,
+  withinDays = 7
+): "expired" | "expiring-soon" | null {
+  if (!expiresAt) return null;
+  const now = Date.now();
+  const expiry = new Date(expiresAt).getTime();
+  if (isNaN(expiry)) return null;
+  if (expiry < now) return "expired";
+  const msUntilExpiry = expiry - now;
+  const msThreshold = withinDays * 24 * 60 * 60 * 1000;
+  if (msUntilExpiry <= msThreshold) return "expiring-soon";
+  return null;
+}


### PR DESCRIPTION
## 변경사항
- lib/utils.ts에 getExpiryStatus 순수 함수 추가: 7일 이내 'expiring-soon', 과거 'expired', 그 외 null
- 계약 목록 행에 expiresAt 기반 배지 표시 (상태 배지 왼쪽)
  - 만료됨: 빨간 'Expired' 배지
  - 7일 이내 임박: 주황 'Expires soon' 배지
  - null/8일 이상: 배지 없음
- sm 이상 화면에서만 표시 (모바일 공간 절약)

## QA 결과
- tsc --noEmit 오류 없음
- ESLint 신규 오류 없음

Closes #101