### PR TITLE
feat(#106,#107,#108): 만료 임박 위젯, 계약 뷰어 만료일 배지, 초대 재전송 버튼

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -16,6 +16,18 @@ import dynamic from "next/dynamic";
 import { useToast } from "@/components/ui/Toast";
 import { LoadingSpinner } from "@/components/ui/primitives";
 
+// ─── Expiry helpers ─────────────────────────────────────────────────────────
+
+function getContractExpiryBadge(expiresAt: string | null): { label: string; cls: string } | null {
+  if (!expiresAt) return null;
+  const days = Math.ceil((new Date(expiresAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+  if (days < 0) return { label: "Expired", cls: "bg-red-50 text-red-600 ring-red-200" };
+  if (days === 0) return { label: "Expires today", cls: "bg-red-50 text-red-600 ring-red-200" };
+  if (days <= 30) return { label: `D-${days}`, cls: "bg-amber-50 text-amber-700 ring-amber-200" };
+  return null;
+}
+
+
 const DocumentViewer = dynamic(
   () => import("@/components/viewer/DocumentViewer"),
   { ssr: false }
@@ -374,6 +386,17 @@ export default function ContractViewerPage({
 
           {/* Right: status + actions */}
           <div className="flex flex-shrink-0 items-center gap-1.5 sm:gap-2">
+            {/* Expiry badge — shown when contract is expiring within 30 days or already expired */}
+            {contract?.expiresAt && (() => {
+              const badge = getContractExpiryBadge(contract.expiresAt);
+              return badge ? (
+                <span
+                  className={`hidden sm:inline-flex rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${badge.cls}`}
+                >
+                  {badge.label}
+                </span>
+              ) : null;
+            })()}
             {/* Document processing badge */}
             {isDocumentProcessing && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 ring-1 ring-zinc-200">

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { formatDate } from "@/lib/utils";
-import type { DashboardStats, ContractStatus } from "@/types";
+import type { Contract, DashboardStats, ContractStatus } from "@/types";
 
 // ─── Status badge helpers (reusing contracts page colours) ─────────────────
 
@@ -22,6 +22,40 @@ const STATUS_COLOR: Record<string, string> = {
   ready: "bg-green-50 text-green-700 ring-green-200",
   failed: "bg-red-50 text-red-600 ring-red-200",
 };
+
+// ─── Expiry helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Returns the number of days until a date string from now.
+ * Negative means it has already expired.
+ */
+function daysUntil(dateStr: string): number {
+  const diff = new Date(dateStr).getTime() - Date.now();
+  return Math.ceil(diff / (1000 * 60 * 60 * 24));
+}
+
+function ExpiryBadge({ expiresAt }: { expiresAt: string }) {
+  const days = daysUntil(expiresAt);
+  if (days < 0) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 ring-1 ring-red-200">
+        Expired
+      </span>
+    );
+  }
+  if (days === 0) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 ring-1 ring-red-200">
+        Expires today
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
+      D-{days}
+    </span>
+  );
+}
 
 // ─── Skeleton helpers ───────────────────────────────────────────────────────
 
@@ -140,6 +174,9 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [expiringContracts, setExpiringContracts] = useState<Contract[]>([]);
+  const [expiringLoading, setExpiringLoading] = useState(true);
+
   const fetchStats = useCallback(async () => {
     if (!orgId) return;
     setLoading(true);
@@ -154,13 +191,31 @@ export default function DashboardPage() {
     }
   }, [orgId]);
 
+  const fetchExpiring = useCallback(async () => {
+    if (!orgId) return;
+    setExpiringLoading(true);
+    try {
+      const data = await api.getExpiringContracts(orgId, 30);
+      setExpiringContracts(data.contracts ?? []);
+    } catch {
+      // Non-critical: silently ignore
+      setExpiringContracts([]);
+    } finally {
+      setExpiringLoading(false);
+    }
+  }, [orgId]);
+
   useEffect(() => {
     fetchStats();
-  }, [fetchStats]);
+    fetchExpiring();
+  }, [fetchStats, fetchExpiring]);
 
   // Wait for user to hydrate before fetching.
   useEffect(() => {
-    if (orgId) fetchStats();
+    if (orgId) {
+      fetchStats();
+      fetchExpiring();
+    }
   }, [orgId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
@@ -200,13 +255,13 @@ export default function DashboardPage() {
           Contract Overview
         </h2>
         {loading ? (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-            {Array.from({ length: 5 }).map((_, i) => (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+            {Array.from({ length: 6 }).map((_, i) => (
               <SkeletonCard key={i} />
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
             <StatCard label="Total" value={stats?.totalContracts ?? 0} />
             <StatCard
               label="Ready"
@@ -227,12 +282,17 @@ export default function DashboardPage() {
               value={stats?.failedContracts ?? 0}
               accent="text-red-600"
             />
+            <StatCard
+              label="Expiring (30d)"
+              value={stats?.expiringSoon ?? 0}
+              accent={(stats?.expiringSoon ?? 0) > 0 ? "text-amber-600" : "text-zinc-900"}
+            />
           </div>
         )}
       </section>
 
-      {/* Bottom two-column section */}
-      <div className="grid gap-6 lg:grid-cols-2">
+      {/* Bottom three-column section */}
+      <div className="grid gap-6 lg:grid-cols-3">
         {/* Risk distribution */}
         <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
           <div className="mb-4 flex items-center justify-between">
@@ -322,6 +382,59 @@ export default function DashboardPage() {
                       <span className="text-xs text-zinc-400">
                         {formatDate(c.createdAt)}
                       </span>
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Expiring soon widget */}
+        <section className="rounded-xl border border-zinc-200 bg-white shadow-sm">
+          <div className="flex items-center justify-between border-b border-zinc-100 px-5 py-4">
+            <h2 className="text-sm font-semibold text-zinc-800">
+              Expiring Soon
+            </h2>
+            <span className="text-xs text-zinc-400">Next 30 days</span>
+          </div>
+
+          {expiringLoading ? (
+            <div className="divide-y divide-zinc-50">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <SkeletonRow key={i} />
+              ))}
+            </div>
+          ) : expiringContracts.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-10 text-sm text-zinc-400">
+              <svg
+                className="h-8 w-8 text-zinc-300"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              No contracts expiring soon.
+            </div>
+          ) : (
+            <ul className="divide-y divide-zinc-50">
+              {expiringContracts.slice(0, 5).map((c) => (
+                <li key={c.id}>
+                  <Link
+                    href={`/contracts/${c.id}`}
+                    className="flex items-center justify-between gap-3 px-5 py-3 transition-colors hover:bg-zinc-50"
+                  >
+                    <span className="truncate text-sm font-medium text-zinc-800">
+                      {c.title}
+                    </span>
+                    <div className="flex flex-shrink-0 items-center gap-2">
+                      {c.expiresAt && <ExpiryBadge expiresAt={c.expiresAt} />}
                     </div>
                   </Link>
                 </li>

--- a/src/app/(app)/settings/organization/page.tsx
+++ b/src/app/(app)/settings/organization/page.tsx
@@ -142,6 +142,7 @@ export default function OrganizationSettingsPage() {
   const [showInvite, setShowInvite] = useState(false);
   const [removing, setRemoving] = useState<string | null>(null);
   const [updatingRole, setUpdatingRole] = useState<string | null>(null);
+  const [resending, setResending] = useState<string | null>(null);
 
   const fetchMembers = () => {
     if (!orgId) return;
@@ -185,6 +186,18 @@ export default function OrganizationSettingsPage() {
       toast("error", getErrorMessage(err, "Failed to update role."));
     } finally {
       setUpdatingRole(null);
+    }
+  }
+
+  async function handleResendInvite(targetEmail: string) {
+    setResending(targetEmail);
+    try {
+      await api.inviteMember(orgId, targetEmail);
+      toast("success", `Invitation re-sent to ${targetEmail}.`);
+    } catch (err: unknown) {
+      toast("error", getErrorMessage(err, "Failed to re-send invitation."));
+    } finally {
+      setResending(null);
     }
   }
 
@@ -299,7 +312,14 @@ export default function OrganizationSettingsPage() {
                             <span className="ml-1.5 text-xs text-zinc-400 font-normal">(you)</span>
                           )}
                         </p>
-                        <p className="truncate text-xs text-zinc-400">{m.email}</p>
+                        <p className="truncate text-xs text-zinc-400">
+                          {m.email}
+                          {!m.emailVerified && (
+                            <span className="ml-1.5 inline-flex items-center rounded-full bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
+                              Unverified
+                            </span>
+                          )}
+                        </p>
                       </div>
                     </div>
 
@@ -329,7 +349,17 @@ export default function OrganizationSettingsPage() {
                       {formatDate(m.joinedAt)}
                     </span>
 
-                    <div className="flex justify-end w-16">
+                    <div className="flex flex-col items-end gap-1 w-24">
+                      {isAdmin && !isSelf && !m.emailVerified && (
+                        <button
+                          onClick={() => handleResendInvite(m.email)}
+                          disabled={resending === m.email}
+                          className="text-xs text-zinc-500 hover:text-indigo-600 transition-colors disabled:opacity-40 whitespace-nowrap"
+                          title="Re-send invitation email"
+                        >
+                          {resending === m.email ? "Sending…" : "Resend invite"}
+                        </button>
+                      )}
                       {isAdmin && !isSelf ? (
                         <button
                           onClick={() => handleRemove(m.userId)}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   MembersResponse,
   Contract,
   ContractListResponse,
+  ExpiringContractsResponse,
   UploadContractResponse,
   IngestionJob,
   Clause,
@@ -448,6 +449,15 @@ async function getSnippets(
   );
 }
 
+async function getExpiringContracts(
+  orgId: string,
+  days = 30
+): Promise<ExpiringContractsResponse> {
+  return request<ExpiringContractsResponse>(
+    `/organizations/${orgId}/contracts/expiring-soon?days=${days}`
+  );
+}
+
 // ─────────────────────────────────────────────
 // Analysis endpoints
 // ─────────────────────────────────────────────
@@ -611,6 +621,7 @@ export const api = {
   listIngestionJobsByContract,
   listClauses,
   getSnippets,
+  getExpiringContracts,
 
   // Analysis
   createAnalysis,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface MemberInfo {
   fullName: string;
   role: string;
   joinedAt: string;
+  emailVerified: boolean;
 }
 
 export interface MembersResponse {
@@ -109,6 +110,12 @@ export interface UpdateContractRequest {
   contractType?: string;
   signedAt?: string;
   expiresAt?: string;
+}
+
+export interface ExpiringContractsResponse {
+  contracts: Contract[];
+  total: number;
+  days: number;
 }
 
 // ─────────────────────────────────────────────
@@ -307,6 +314,7 @@ export interface DashboardStats {
   readyContracts: number;
   failedContracts: number;
   recentAnalyses: number;
+  expiringSoon: number;
   riskDistribution: RiskDistribution;
   recentContracts: DashboardRecentContract[];
 }


### PR DESCRIPTION
## 변경사항

### Dashboard (#106)
- Contract Overview에 "Expiring (30d)" 요약 카드 추가 (API expiringSoon 필드)
- "Expiring Soon" 위젯 신규 추가 — 30일 이내 만료 계약 최대 5개, D-N 배지 표시
- 레이아웃을 2컬럼에서 3컬럼으로 확장 (리스크 분포 / 최근 계약 / 만료 임박)
- api.getExpiringContracts() 신규 메서드 추가 (GET /organizations/{orgId}/contracts/expiring-soon)

### Contract Viewer (#107)
- 툴바 우측에 만료일 배지 추가
  - 이미 만료: "Expired" 빨간 배지
  - 30일 이내 만료: "D-N" 노란 배지
  - expiresAt 미설정 또는 30일 초과 시 배지 숨김

### Settings Organization (#108)
- 이메일 미인증 멤버 이메일 옆 "Unverified" 앰버 배지 표시
- 어드민에게 미인증 멤버 행에 "Resend invite" 버튼 노출
- 재전송 성공/실패 토스트 처리

### Types/API
- DashboardStats.expiringSoon 필드 추가
- MemberInfo.emailVerified 필드 추가
- ExpiringContractsResponse 타입 추가

## QA 결과
- next build 성공 (TypeScript 타입 체크 포함)
- 15개 페이지 정적 생성 완료

Closes #106
Closes #107
Closes #108