### PR TITLE
feat(#113): 계약 뷰어 조항 리스크 필터 + 대시보드 만료 구간 통계

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -124,3 +124,41 @@
 | UI 스타일 | Tailwind CSS v4 |
 
 *최종 업데이트: 2026-03-27*
+
+---
+
+## ADR-012: 조항 리스크 필터 — ClauseNav 내부 상태 관리
+
+**날짜**: 2026-04-01
+
+**결정**: 리스크 필터 상태(`activeFilters: Set<RiskLevel>`)를 ClauseNav 컴포넌트 내부 state로 관리한다.
+
+**이유**:
+- 필터는 ClauseNav 뷰 전용 UI 상태이므로 상위 컴포넌트(ContractViewerPage)에 올릴 필요 없음
+- 여러 뷰어 인스턴스(데스크톱 사이드바 + 모바일 드로어)가 독립적인 필터 상태를 가져도 무관
+- 분석 미완료 시 필터 UI를 숨기는 로직도 ClauseNav 내부에서 처리 가능
+
+**설계**:
+- 빈 Set = 전체 표시 (기본값)
+- 필터 적용 시: analyzed 조항은 필터 매칭만, unanalyzed(none) 조항은 항상 표시
+- ClauseNav 외부 인터페이스(props)는 변경 없음
+
+**영향**: 없음 (ContractViewerPage 변경 불필요)
+
+---
+
+## ADR-013: 대시보드 만료 구간 통계 — expiryBuckets 필드 추가
+
+**날짜**: 2026-04-01
+
+**결정**: DashboardStats 응답에 `expiryBuckets: { days30, days60, days90 }` 필드를 추가한다. 기존 `expiringSoon` 필드는 하위 호환성을 위해 유지하되 deprecated 처리.
+
+**이유**:
+- 30일 단일 버킷만으로는 계약 만료 우선순위를 판단하기 어려움
+- 30/60/90일 구간으로 나누면 중장기 갱신 계획 수립 가능
+- API는 단일 쿼리에 3개 COUNT FILTER를 추가하여 N+1 없이 처리
+
+**대시보드 UI 설계**:
+- 가로 막대 그래프로 3개 구간 시각화 (Within 30 / 31-60 / 61-90)
+- 각 막대 너비: 최대값 대비 상대 비율
+- 0인 구간도 표시 (상태 명확성)

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -149,17 +149,98 @@ function RiskBar({ high, medium, low }: RiskBarProps) {
       <div className="flex flex-wrap gap-4 text-xs">
         <span className="flex items-center gap-1.5 text-zinc-600">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-red-500" />
-          High — {high} ({highPct}%)
+          High &mdash; {high} ({highPct}%)
         </span>
         <span className="flex items-center gap-1.5 text-zinc-600">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-amber-400" />
-          Medium — {medium} ({medPct}%)
+          Medium &mdash; {medium} ({medPct}%)
         </span>
         <span className="flex items-center gap-1.5 text-zinc-600">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-green-400" />
-          Low — {low} ({lowPct}%)
+          Low &mdash; {low} ({lowPct}%)
         </span>
       </div>
+    </div>
+  );
+}
+
+// ─── Expiry buckets widget ───────────────────────────────────────────────────
+
+interface ExpiryBucketsWidgetProps {
+  days30: number;
+  days60: number;
+  days90: number;
+}
+
+function ExpiryBucketsWidget({ days30, days60, days90 }: ExpiryBucketsWidgetProps) {
+  // Only contracts expiring *between* buckets (exclusive increments).
+  const between30and60 = days60 - days30;
+  const between60and90 = days90 - days60;
+
+  const buckets = [
+    {
+      label: "Within 30 days",
+      count: days30,
+      barClass: "bg-red-500",
+      textClass: "text-red-700",
+      bgClass: "bg-red-50",
+      ringClass: "ring-red-200",
+    },
+    {
+      label: "31 – 60 days",
+      count: between30and60,
+      barClass: "bg-amber-400",
+      textClass: "text-amber-700",
+      bgClass: "bg-amber-50",
+      ringClass: "ring-amber-200",
+    },
+    {
+      label: "61 – 90 days",
+      count: between60and90,
+      barClass: "bg-yellow-300",
+      textClass: "text-yellow-700",
+      bgClass: "bg-yellow-50",
+      ringClass: "ring-yellow-200",
+    },
+  ];
+
+  const maxCount = Math.max(days30, between30and60, between60and90, 1);
+
+  if (days90 === 0) {
+    return (
+      <p className="text-sm text-zinc-400">
+        No contracts expiring within 90 days.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {buckets.map(({ label, count, barClass, textClass, bgClass, ringClass }) => (
+        <div key={label} className="flex items-center gap-3">
+          <span className="w-28 flex-shrink-0 text-xs text-zinc-500">{label}</span>
+          <div className="flex flex-1 items-center gap-2">
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-zinc-100">
+              <div
+                className={`h-full rounded-full transition-all ${barClass}`}
+                style={{ width: `${Math.round((count / maxCount) * 100)}%` }}
+              />
+            </div>
+            {count > 0 ? (
+              <span
+                className={`inline-flex min-w-[1.75rem] items-center justify-center rounded-full px-1.5 py-0.5 text-xs font-medium ring-1 ${bgClass} ${textClass} ${ringClass}`}
+              >
+                {count}
+              </span>
+            ) : (
+              <span className="min-w-[1.75rem] text-center text-xs text-zinc-300">0</span>
+            )}
+          </div>
+        </div>
+      ))}
+      <p className="mt-1 text-xs text-zinc-400">
+        {days90} total expiring within 90 days
+      </p>
     </div>
   );
 }
@@ -284,8 +365,12 @@ export default function DashboardPage() {
             />
             <StatCard
               label="Expiring (30d)"
-              value={stats?.expiringSoon ?? 0}
-              accent={(stats?.expiringSoon ?? 0) > 0 ? "text-amber-600" : "text-zinc-900"}
+              value={stats?.expiryBuckets?.days30 ?? stats?.expiringSoon ?? 0}
+              accent={
+                (stats?.expiryBuckets?.days30 ?? stats?.expiringSoon ?? 0) > 0
+                  ? "text-amber-600"
+                  : "text-zinc-900"
+              }
             />
           </div>
         )}
@@ -443,6 +528,40 @@ export default function DashboardPage() {
           )}
         </section>
       </div>
+
+      {/* Expiry timeline section — 30/60/90-day buckets */}
+      <section className="mt-6 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-zinc-800">
+            Expiry Timeline
+          </h2>
+          <Link
+            href="/contracts?status=ready"
+            className="text-xs font-medium text-zinc-500 hover:text-zinc-800"
+          >
+            Manage contracts
+          </Link>
+        </div>
+        {loading ? (
+          <div className="space-y-3 animate-pulse">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <div className="h-3 w-28 rounded bg-zinc-100" />
+                <div className="h-2 flex-1 rounded-full bg-zinc-100" />
+                <div className="h-5 w-6 rounded-full bg-zinc-100" />
+              </div>
+            ))}
+          </div>
+        ) : stats?.expiryBuckets ? (
+          <ExpiryBucketsWidget
+            days30={stats.expiryBuckets.days30}
+            days60={stats.expiryBuckets.days60}
+            days90={stats.expiryBuckets.days90}
+          />
+        ) : (
+          <p className="text-sm text-zinc-400">No expiry data available.</p>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import type { Clause, ClauseResult, RiskLevel } from "@/types";
 import RiskBadge from "@/components/risk/RiskBadge";
 
@@ -21,6 +22,25 @@ const RISK_INDICATOR: Record<RiskLevel, string> = {
   none: "bg-zinc-300",
 };
 
+// All filterable risk levels (excludes "none" — unanalyzed clauses are always shown)
+const FILTER_LEVELS: Array<{ level: RiskLevel; label: string; activeClass: string }> = [
+  {
+    level: "HIGH",
+    label: "HIGH",
+    activeClass: "bg-red-100 text-red-700 ring-red-300",
+  },
+  {
+    level: "MEDIUM",
+    label: "MED",
+    activeClass: "bg-amber-100 text-amber-700 ring-amber-300",
+  },
+  {
+    level: "LOW",
+    label: "LOW",
+    activeClass: "bg-green-100 text-green-700 ring-green-300",
+  },
+];
+
 export default function ClauseNav({
   clauses,
   clauseResults,
@@ -30,20 +50,109 @@ export default function ClauseNav({
   const resultMap = buildResultMap(clauseResults);
   const analyzedCount = clauseResults.length;
 
+  // Set of active filter levels. Empty set = show all.
+  const [activeFilters, setActiveFilters] = useState<Set<RiskLevel>>(new Set());
+
+  function toggleFilter(level: RiskLevel) {
+    setActiveFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) {
+        next.delete(level);
+      } else {
+        next.add(level);
+      }
+      return next;
+    });
+  }
+
+  function clearFilters() {
+    setActiveFilters(new Set());
+  }
+
+  // Derive the effective risk level of a clause (respecting overrides).
+  function getEffectiveRiskLevel(clause: Clause): RiskLevel {
+    const result = resultMap.get(clause.id);
+    if (!result) return "none";
+    return (result.overriddenRiskLevel as RiskLevel | null) ?? result.riskLevel;
+  }
+
+  // Apply filter: if no active filters, show all. Otherwise show only matching.
+  const visibleClauses =
+    activeFilters.size === 0
+      ? clauses
+      : clauses.filter((clause) => {
+          const level = getEffectiveRiskLevel(clause);
+          // Always show unanalyzed clauses when filtering — they have no risk level.
+          if (level === "none") return true;
+          return activeFilters.has(level);
+        });
+
+  const hasAnalysis = analyzedCount > 0;
+
   return (
     <nav className="flex h-full flex-col">
       {/* Header */}
       <div className="border-b border-zinc-100 px-4 py-3.5">
-        <p className="text-xs font-semibold text-zinc-900">
-          Clauses
-          <span className="ml-1.5 font-normal text-zinc-400">
-            ({clauses.length})
-          </span>
-        </p>
-        {analyzedCount > 0 && (
-          <p className="mt-0.5 text-xs text-zinc-400">
-            {analyzedCount} analyzed
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold text-zinc-900">
+            Clauses
+            <span className="ml-1.5 font-normal text-zinc-400">
+              ({activeFilters.size > 0 ? `${visibleClauses.length}/` : ""}
+              {clauses.length})
+            </span>
           </p>
+          {hasAnalysis && activeFilters.size > 0 && (
+            <button
+              onClick={clearFilters}
+              className="cursor-pointer text-xs text-zinc-400 hover:text-zinc-600 transition-colors"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        {hasAnalysis && (
+          <p className="mt-0.5 text-xs text-zinc-400">{analyzedCount} analyzed</p>
+        )}
+
+        {/* Risk filter toggles — shown only when analysis results are available */}
+        {hasAnalysis && (
+          <div className="mt-2.5 flex items-center gap-1.5">
+            {FILTER_LEVELS.map(({ level, label, activeClass }) => {
+              const isActive = activeFilters.has(level);
+              // Count clauses at this risk level (considering overrides).
+              const count = clauseResults.filter((r) => {
+                const effective =
+                  (r.overriddenRiskLevel as RiskLevel | null) ?? r.riskLevel;
+                return effective === level;
+              }).length;
+
+              return (
+                <button
+                  key={level}
+                  onClick={() => toggleFilter(level)}
+                  title={`Filter by ${level} risk (${count} clauses)`}
+                  className={[
+                    "cursor-pointer inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ring-1 transition-colors",
+                    isActive
+                      ? activeClass
+                      : "bg-zinc-50 text-zinc-500 ring-zinc-200 hover:bg-zinc-100",
+                  ].join(" ")}
+                >
+                  {label}
+                  {count > 0 && (
+                    <span
+                      className={[
+                        "tabular-nums rounded-full px-1 text-xs",
+                        isActive ? "opacity-80" : "text-zinc-400",
+                      ].join(" ")}
+                    >
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
         )}
       </div>
 
@@ -62,10 +171,31 @@ export default function ClauseNav({
         </div>
       )}
 
+      {/* Filter empty state — all clauses filtered out */}
+      {clauses.length > 0 && visibleClauses.length === 0 && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 px-4 py-10 text-center">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-zinc-100">
+            <svg className="h-4 w-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L13 13.414V19a1 1 0 01-.553.894l-4 2A1 1 0 017 21v-7.586L3.293 6.707A1 1 0 013 6V4z" />
+            </svg>
+          </div>
+          <p className="text-xs text-zinc-400 leading-relaxed">
+            No clauses match the selected filter.
+          </p>
+          <button
+            onClick={clearFilters}
+            className="cursor-pointer text-xs text-zinc-500 underline underline-offset-2 hover:text-zinc-700"
+          >
+            Clear filter
+          </button>
+        </div>
+      )}
+
       {/* List */}
-      {clauses.length > 0 && (
+      {visibleClauses.length > 0 && (
         <ul className="flex-1 overflow-y-auto space-y-0.5 px-2 py-2">
-          {clauses.map((clause) => {
+          {visibleClauses.map((clause) => {
             const result = resultMap.get(clause.id);
             const riskLevel: RiskLevel =
               (result?.overriddenRiskLevel as RiskLevel | null) ??

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,6 +196,8 @@ export interface ClauseResult {
   analysisId: string;
   clauseId: string;
   riskLevel: RiskLevel;
+  /** LLM confidence score: 0.0 (uncertain) to 1.0 (highly certain). Default 0.5. */
+  confidence: number;
   issueType: string | null;
   summary: string | null;
   highlightX: number | null;
@@ -307,6 +309,13 @@ export interface DashboardRecentContract {
   createdAt: string;
 }
 
+/** Contracts expiring within each day-bucket (only future contracts counted). */
+export interface ExpiryBuckets {
+  days30: number;
+  days60: number;
+  days90: number;
+}
+
 export interface DashboardStats {
   totalContracts: number;
   uploadedContracts: number;
@@ -314,7 +323,9 @@ export interface DashboardStats {
   readyContracts: number;
   failedContracts: number;
   recentAnalyses: number;
+  /** @deprecated Use expiryBuckets.days30 — kept for backward compatibility */
   expiringSoon: number;
+  expiryBuckets: ExpiryBuckets;
   riskDistribution: RiskDistribution;
   recentContracts: DashboardRecentContract[];
 }


### PR DESCRIPTION
## 변경사항

### 계약 뷰어 — 조항 리스크 필터 (issue #113)
- ClauseNav 헤더에 HIGH / MED / LOW 토글 버튼 추가 (분석 완료 시에만 표시)
- 다중 선택 지원: 여러 레벨 동시 필터링 가능
- 미분석 조항(risk = none)은 필터 적용 중에도 항상 표시
- Clear 버튼으로 전체 필터 해제
- 모든 조항이 필터로 숨겨지면 빈 상태 + "Clear filter" 링크
- 표시 카운트: 필터 적용 시 `visible/total` 형식으로 헤더 업데이트
- 모바일 드로어에서도 동일 동작 (동일 컴포넌트 재사용)

### 대시보드 — 만료 구간 통계
- `DashboardStats` 타입에 `expiryBuckets: { days30, days60, days90 }` 추가
- `ClauseResult` 타입에 `confidence: number` 필드 추가
- `ExpiryBucketsWidget` 컴포넌트: Within 30 / 31-60 / 61-90일 가로 막대 시각화
- 대시보드 하단에 "Expiry Timeline" 섹션 신설
- Stat 카드 "Expiring (30d)": `expiryBuckets.days30` 우선, fallback `expiringSoon`

## QA 결과
- TypeScript 컴파일: PASS (tsc --noEmit, 0 errors)
- ESLint (수정 파일 대상): PASS (0 errors, 0 warnings)
- 기존 props 인터페이스(ClauseNavProps) 변경 없음 — 상위 컴포넌트 수정 불필요

Closes #113