### PR TITLE
feat(#116): 전체 UI 한국어 로컬라이제이션

### DIFF
--- a/src/app/(app)/audit-logs/page.tsx
+++ b/src/app/(app)/audit-logs/page.tsx
@@ -31,7 +31,7 @@ function csvEscape(value: string | null | undefined): string {
 }
 
 function eventsToCSV(events: AuditEvent[]): string {
-  const headers = ["Time", "Actor", "Action", "Target Type", "Target ID", "IP Address", "Context"];
+  const headers = ["시간", "행위자", "액션", "대상 유형", "대상 ID", "IP 주소", "컨텍스트"];
   const rows = events.map((e) => [
     new Date(e.createdAt).toISOString(),
     e.actorEmail ?? "",
@@ -86,7 +86,7 @@ function EventRow({ event }: { event: AuditEvent }) {
       <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-start sm:gap-4 sm:px-5 sm:py-3.5">
         {/* Timestamp */}
         <span className="w-36 flex-shrink-0 text-xs text-zinc-400 tabular-nums">
-          {new Date(event.createdAt).toLocaleString("en-US", {
+          {new Date(event.createdAt).toLocaleString("ko-KR", {
             month: "short",
             day: "numeric",
             hour: "2-digit",
@@ -101,7 +101,7 @@ function EventRow({ event }: { event: AuditEvent }) {
               {event.actorEmail}
             </p>
           ) : (
-            <span className="text-xs text-zinc-400">System</span>
+            <span className="text-xs text-zinc-400">시스템</span>
           )}
         </div>
 
@@ -128,7 +128,7 @@ function EventRow({ event }: { event: AuditEvent }) {
               onClick={() => setExpanded((v) => !v)}
               className="cursor-pointer self-start text-xs text-zinc-400 transition-colors hover:text-zinc-600"
             >
-              {expanded ? "Hide details" : "Show details"}
+              {expanded ? "상세 숨기기" : "상세 보기"}
             </button>
           )}
           {expanded && hasContext && (
@@ -285,12 +285,12 @@ export default function AuditLogsPage() {
       {/* Page header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-xl font-semibold text-zinc-900">Audit Log</h1>
+          <h1 className="text-xl font-semibold text-zinc-900">감사 로그</h1>
           {loadState === "success" && (
             <p className="mt-0.5 text-sm text-zinc-400">
-              {total.toLocaleString()} event{total !== 1 ? "s" : ""}
+              {total.toLocaleString()}건
               {hasActiveFilters && (
-                <span className="ml-1 text-zinc-400">matching current filters</span>
+                <span className="ml-1 text-zinc-400">현재 필터 조건 기준</span>
               )}
             </p>
           )}
@@ -300,13 +300,13 @@ export default function AuditLogsPage() {
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:gap-3">
           {/* Action filter */}
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-zinc-500">Action</label>
+            <label className="text-xs text-zinc-500">액션</label>
             <select
               value={actionFilter}
               onChange={(e) => setActionFilter(e.target.value)}
               className="cursor-pointer rounded-lg border border-zinc-200 bg-white px-2.5 py-1.5 text-xs text-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-900/10 transition-colors hover:border-zinc-300"
             >
-              <option value="">All actions</option>
+              <option value="">전체 액션</option>
               {ACTION_OPTIONS.map((a) => (
                 <option key={a} value={a}>
                   {a.replace(/_/g, " ")}
@@ -317,7 +317,7 @@ export default function AuditLogsPage() {
 
           {/* Date range */}
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-zinc-500">From</label>
+            <label className="text-xs text-zinc-500">시작일</label>
             <input
               type="date"
               value={fromDate}
@@ -327,7 +327,7 @@ export default function AuditLogsPage() {
             />
           </div>
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-zinc-500">To</label>
+            <label className="text-xs text-zinc-500">종료일</label>
             <input
               type="date"
               value={toDate}
@@ -342,7 +342,7 @@ export default function AuditLogsPage() {
               onClick={clearFilters}
               className="cursor-pointer self-end rounded-lg border border-zinc-200 px-2.5 py-1.5 text-xs text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-700 whitespace-nowrap"
             >
-              Clear filters
+              필터 초기화
             </button>
           )}
 
@@ -355,7 +355,7 @@ export default function AuditLogsPage() {
             {exportState === "loading" ? (
               <>
                 <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-600" />
-                Exporting&hellip;
+                내보내는 중&hellip;
               </>
             ) : (
               <>
@@ -372,7 +372,7 @@ export default function AuditLogsPage() {
                     d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
                   />
                 </svg>
-                Export CSV
+                CSV 내보내기
               </>
             )}
           </button>
@@ -386,13 +386,13 @@ export default function AuditLogsPage() {
       {loadState === "error" && (
         <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-center">
           <p className="text-sm font-medium text-red-700">
-            Failed to load audit events.
+            감사 이벤트를 불러오지 못했습니다.
           </p>
           <button
             onClick={fetchEvents}
             className="mt-2 cursor-pointer text-sm font-medium text-red-800 underline underline-offset-2 hover:no-underline"
           >
-            Try again
+            다시 시도
           </button>
         </div>
       )}
@@ -415,18 +415,18 @@ export default function AuditLogsPage() {
               />
             </svg>
           </div>
-          <p className="text-sm font-medium text-zinc-700">No audit events found</p>
+          <p className="text-sm font-medium text-zinc-700">감사 이벤트가 없습니다</p>
           <p className="mt-1 text-sm text-zinc-400">
             {hasActiveFilters
-              ? "No events match the current filters."
-              : "Actions within this organization will appear here."}
+              ? "현재 필터 조건에 맞는 이벤트가 없습니다."
+              : "이 조직 내의 활동이 여기에 표시됩니다."}
           </p>
           {hasActiveFilters && (
             <button
               onClick={clearFilters}
               className="cursor-pointer mt-4 text-sm font-medium text-zinc-700 underline underline-offset-2 hover:no-underline"
             >
-              Clear filters
+              필터 초기화
             </button>
           )}
         </div>
@@ -438,13 +438,13 @@ export default function AuditLogsPage() {
           {/* Column headers — desktop only */}
           <div className="hidden border-b border-zinc-100 sm:flex items-center gap-4 px-5 py-2.5">
             <span className="w-36 flex-shrink-0 text-xs font-semibold uppercase tracking-wide text-zinc-400">
-              Time
+              시간
             </span>
             <span className="w-44 flex-shrink-0 text-xs font-semibold uppercase tracking-wide text-zinc-400">
-              Actor
+              행위자
             </span>
             <span className="flex-1 text-xs font-semibold uppercase tracking-wide text-zinc-400">
-              Action
+              액션
             </span>
             <span className="hidden lg:block flex-shrink-0 text-xs font-semibold uppercase tracking-wide text-zinc-400">
               IP
@@ -464,7 +464,7 @@ export default function AuditLogsPage() {
       {/* Progress indicator */}
       {loadState === "success" && events.length > 0 && (
         <p className="text-center text-xs text-zinc-400">
-          Showing {events.length.toLocaleString()} of {total.toLocaleString()} events
+          {total.toLocaleString()}건 중 {events.length.toLocaleString()}건 표시 중
         </p>
       )}
 
@@ -479,10 +479,10 @@ export default function AuditLogsPage() {
             {loadMoreState === "loading" ? (
               <span className="flex items-center gap-2">
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-600" />
-                Loading&hellip;
+                로딩 중&hellip;
               </span>
             ) : (
-              `Load ${Math.min(PAGE_SIZE, total - events.length)} more (${(total - events.length).toLocaleString()} remaining)`
+              `더 보기 ${Math.min(PAGE_SIZE, total - events.length)}건 (${(total - events.length).toLocaleString()}건 남음)`
             )}
           </button>
         </div>

--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -403,29 +403,29 @@ export default function ContractViewerPage({
             {isDocumentProcessing && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 ring-1 ring-zinc-200">
                 <span className="h-1.5 w-1.5 animate-spin rounded-full border border-zinc-400 border-t-transparent" />
-                <span className="hidden sm:inline">Processing</span>
+                <span className="hidden sm:inline">처리 중</span>
               </span>
             )}
             {isDocumentFailed && (
               <span className="rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-600 ring-1 ring-red-200 hidden sm:inline-flex">
-                Processing failed
+                처리 실패
               </span>
             )}
 
             {analysis?.status === "completed" && !isDocumentProcessing && (
               <span className="text-xs text-zinc-400 hidden sm:inline tabular-nums">
-                {clauseResults.length} clauses
+                {clauseResults.length}개 조항
               </span>
             )}
             {analysis?.status === "failed" && !isDocumentProcessing && (
               <span className="rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-600 ring-1 ring-red-200 hidden sm:inline-flex">
-                Analysis failed
+                분석 실패
               </span>
             )}
             {(analysisState.phase === "polling" || analysis?.status === "running") && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
                 <span className="h-1.5 w-1.5 animate-ping rounded-full bg-amber-400" />
-                Analyzing
+                분석 중
               </span>
             )}
 
@@ -434,13 +434,13 @@ export default function ContractViewerPage({
               <button
                 onClick={() => setShowClauseDrawer(true)}
                 className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 md:hidden"
-                title="View clauses"
+                title="조항 목록 보기"
               >
                 <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                     d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
-                <span>Clauses</span>
+                <span>조항</span>
                 {clauseResults.length > 0 && (
                   <span className="rounded-full bg-zinc-100 px-1.5 py-0.5 text-xs tabular-nums">
                     {clauseResults.length}
@@ -453,7 +453,7 @@ export default function ContractViewerPage({
               <button
                 onClick={() => setShowEditModal(true)}
                 className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
-                title="Edit contract metadata"
+                title="계약서 정보 수정"
               >
                 <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path
@@ -463,7 +463,7 @@ export default function ContractViewerPage({
                     d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                   />
                 </svg>
-                <span className="hidden sm:inline">Edit</span>
+                <span className="hidden sm:inline">수정</span>
               </button>
             )}
 
@@ -471,13 +471,13 @@ export default function ContractViewerPage({
               <button
                 onClick={handleRequestAnalysis}
                 className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
-                title="Re-run AI analysis"
+                title="AI 분석 재실행"
               >
                 <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                     d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                 </svg>
-                <span className="hidden sm:inline">Re-analyze</span>
+                <span className="hidden sm:inline">재분석</span>
               </button>
             ) : (
               <button
@@ -485,11 +485,11 @@ export default function ContractViewerPage({
                 disabled={isAnalysisDisabled}
                 title={
                   isDocumentProcessing
-                    ? "Document is still being processed"
+                    ? "문서를 아직 처리 중입니다"
                     : isDocumentFailed
-                    ? "Document processing failed"
+                    ? "문서 처리에 실패했습니다"
                     : clauses.length === 0
-                    ? "No clauses extracted yet"
+                    ? "아직 추출된 조항이 없습니다"
                     : undefined
                 }
                 className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg bg-zinc-900 px-2.5 py-1.5 text-xs font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
@@ -521,11 +521,11 @@ export default function ContractViewerPage({
               {contract ? PROCESSING_STEP_LABEL[contract.status] ?? "Processing…" : "Processing…"}
             </p>
             <p className="mt-1.5 text-xs text-zinc-400">
-              Extracting clauses from your document. This usually takes under a minute.
+              문서에서 조항을 추출하고 있습니다. 보통 1분 이내에 완료됩니다.
             </p>
             <div className="mt-5 flex items-center gap-2 text-xs text-zinc-400">
               <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />
-              <span>Checking for updates…</span>
+              <span>업데이트 확인 중…</span>
             </div>
           </div>
         )}
@@ -556,9 +556,9 @@ export default function ContractViewerPage({
                 </svg>
               </div>
               <div>
-                <p className="text-sm font-semibold text-indigo-900">This contract hasn&#39;t been analyzed yet</p>
+                <p className="text-sm font-semibold text-indigo-900">이 계약서는 아직 분석되지 않았습니다</p>
                 <p className="mt-0.5 text-xs text-indigo-700">
-                  Run AI analysis to identify risks, flag unusual clauses, and get recommendations.
+                  AI 분석을 실행하여 리스크를 파악하고 이상 조항을 찾아 권장 사항을 받아보세요.
                 </p>
               </div>
             </div>
@@ -570,7 +570,7 @@ export default function ContractViewerPage({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                   d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
               </svg>
-              Run AI Analysis
+              AI 분석 실행
             </button>
           </div>
         )}
@@ -597,8 +597,8 @@ export default function ContractViewerPage({
                     />
                   </svg>
                 </div>
-                <p className="text-sm font-medium text-zinc-500">Document preview not available</p>
-                <p className="mt-1 text-xs text-zinc-400">The clauses are listed in the sidebar.</p>
+                <p className="text-sm font-medium text-zinc-500">문서 미리보기를 사용할 수 없습니다</p>
+                <p className="mt-1 text-xs text-zinc-400">조항 목록은 사이드바에서 확인할 수 있습니다.</p>
               </div>
             )
           )
@@ -653,7 +653,7 @@ export default function ContractViewerPage({
             <div className="flex flex-shrink-0 items-center justify-between border-b border-zinc-100 px-4 py-3">
               <div className="flex items-center gap-2">
                 <div className="mx-auto h-1 w-8 rounded-full bg-zinc-200" />
-                <span className="ml-2 text-sm font-semibold text-zinc-900">Clauses</span>
+                <span className="ml-2 text-sm font-semibold text-zinc-900">조항</span>
                 {clauses.length > 0 && (
                   <span className="rounded-full bg-zinc-100 px-1.5 py-0.5 text-xs text-zinc-500 tabular-nums">
                     {clauses.length}
@@ -663,7 +663,7 @@ export default function ContractViewerPage({
               <button
                 onClick={() => setShowClauseDrawer(false)}
                 className="cursor-pointer flex h-7 w-7 items-center justify-center rounded-full text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700"
-                aria-label="Close clause list"
+                aria-label="조항 목록 닫기"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -691,7 +691,7 @@ export default function ContractViewerPage({
           onSaved={(updated) => {
             setContract(updated);
             setShowEditModal(false);
-            toast("success", "Contract updated.");
+            toast("success", "계약서가 업데이트되었습니다.");
           }}
         />
       )}

--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -26,10 +26,10 @@ interface ActiveUpload {
 }
 
 const STATUS_LABEL: Record<string, string> = {
-  uploaded: "Uploaded",
-  processing: "Processing",
-  ready: "Ready",
-  failed: "Failed",
+  uploaded: "업로드됨",
+  processing: "처리 중",
+  ready: "분석 완료",
+  failed: "실패",
 };
 
 const STATUS_COLOR: Record<string, string> = {
@@ -180,7 +180,7 @@ export default function ContractsPage() {
       setShowUpload(false);
       fetchContracts({ silent: true });
     } catch (err: unknown) {
-      toast("error", `Upload failed: ${getErrorMessage(err, "Unknown error")}`);
+      toast("error", `업로드 실패: ${getErrorMessage(err, "알 수 없는 오류")}`);
     } finally {
       setUploading(false);
       setUploadPercent(0);
@@ -192,7 +192,7 @@ export default function ContractsPage() {
       prev.map((u) => (u.jobId === jobId ? { ...u, done: true } : u))
     );
     fetchContracts({ silent: true });
-    toast("success", "Document processed and ready for analysis.");
+    toast("success", "문서 처리가 완료되어 분석할 준비가 됐습니다.");
   }
 
   function openDeleteDialog(e: React.MouseEvent, contract: Contract) {
@@ -208,7 +208,7 @@ export default function ContractsPage() {
       setDeleteDialog({ open: false, contractId: "", contractTitle: "" });
       fetchContracts({ silent: true });
     } catch (err: unknown) {
-      toast("error", `Delete failed: ${getErrorMessage(err, "Unknown error")}`);
+      toast("error", `삭제 실패: ${getErrorMessage(err, "알 수 없는 오류")}`);
     } finally {
       setDeleting(false);
     }
@@ -257,9 +257,9 @@ export default function ContractsPage() {
     setSelectedIds(new Set());
     fetchContracts({ silent: true });
     if (failed > 0) {
-      toast("error", `${failed} contract${failed !== 1 ? "s" : ""} could not be deleted.`);
+      toast("error", `${failed}개 계약서를 삭제하지 못했습니다.`);
     } else {
-      toast("success", `${ids.length} contract${ids.length !== 1 ? "s" : ""} deleted.`);
+      toast("success", `${ids.length}개 계약서가 삭제됐습니다.`);
     }
   }
 
@@ -273,12 +273,12 @@ export default function ContractsPage() {
       {/* Page header */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold text-zinc-900">Contracts</h1>
+          <h1 className="text-xl font-semibold text-zinc-900">계약서</h1>
           {loadState === "success" && (
             <p className="mt-0.5 text-sm text-zinc-400">
-              {total} contract{total !== 1 ? "s" : ""}
+              총 {total}건
               {hasActiveFilters && (
-                <span className="ml-1 text-zinc-400">matching current filters</span>
+                <span className="ml-1 text-zinc-400">현재 필터 조건 기준</span>
               )}
             </p>
           )}
@@ -293,13 +293,13 @@ export default function ContractsPage() {
           ].join(" ")}
         >
           {showUpload ? (
-            "Cancel"
+            "취소"
           ) : (
             <>
               <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
               </svg>
-              Upload contract
+              계약서 업로드
             </>
           )}
         </button>
@@ -308,17 +308,17 @@ export default function ContractsPage() {
       {/* Upload panel */}
       {showUpload && (
         <div className="animate-slide-in rounded-xl border border-zinc-200 bg-white p-6 shadow-sm space-y-4">
-          <h2 className="text-sm font-semibold text-zinc-900">Upload a new contract</h2>
+          <h2 className="text-sm font-semibold text-zinc-900">새 계약서 업로드</h2>
           <div>
             <label className="mb-1.5 block text-sm font-medium text-zinc-700">
-              Title{" "}
-              <span className="font-normal text-zinc-400">(optional)</span>
+              제목{" "}
+              <span className="font-normal text-zinc-400">(선택)</span>
             </label>
             <input
               type="text"
               value={uploadTitle}
               onChange={(e) => setUploadTitle(e.target.value)}
-              placeholder="e.g. NDA with Acme Corp"
+              placeholder="예: Acme Corp NDA"
               className="w-full rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
             />
           </div>
@@ -326,7 +326,7 @@ export default function ContractsPage() {
           {uploading && (
             <div className="space-y-2">
               <div className="flex items-center justify-between text-xs text-zinc-500">
-                <span>Uploading&hellip;</span>
+                <span>업로드 중&hellip;</span>
                 <span className="font-medium tabular-nums">{uploadPercent}%</span>
               </div>
               <div className="h-1 w-full overflow-hidden rounded-full bg-zinc-100">
@@ -394,14 +394,14 @@ export default function ContractsPage() {
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search by title or filename&hellip;"
+            placeholder="제목 또는 파일명으로 검색&hellip;"
             className="w-full rounded-lg border border-zinc-200 bg-white py-2 pl-9 pr-3.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
           />
           {searchQuery && (
             <button
               onClick={() => setSearchQuery("")}
               className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-zinc-400 hover:text-zinc-600"
-              aria-label="Clear search"
+              aria-label="검색 초기화"
             >
               <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -417,7 +417,7 @@ export default function ContractsPage() {
             onChange={(e) => setStatusFilter(e.target.value as ContractStatus | "")}
             className="rounded-lg border border-zinc-200 bg-white py-2 pl-3 pr-8 text-sm text-zinc-700 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
           >
-            <option value="">All statuses</option>
+            <option value="">전체 상태</option>
             {STATUS_OPTIONS.map((s) => (
               <option key={s} value={s}>
                 {STATUS_LABEL[s]}
@@ -430,7 +430,7 @@ export default function ContractsPage() {
               onClick={clearFilters}
               className="cursor-pointer rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-700 whitespace-nowrap"
             >
-              Clear
+              초기화
             </button>
           )}
         </div>
@@ -446,12 +446,12 @@ export default function ContractsPage() {
       {/* Error */}
       {loadState === "error" && (
         <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-center">
-          <p className="text-sm font-medium text-red-700">Failed to load contracts.</p>
+          <p className="text-sm font-medium text-red-700">계약서를 불러오지 못했습니다.</p>
           <button
             onClick={() => fetchContracts()}
             className="mt-2 text-sm font-medium text-red-800 underline underline-offset-2 hover:no-underline"
           >
-            Try again
+            다시 시도
           </button>
         </div>
       )}
@@ -469,9 +469,9 @@ export default function ContractsPage() {
               />
             </svg>
           </div>
-          <p className="text-sm font-medium text-zinc-700">No contracts yet</p>
+          <p className="text-sm font-medium text-zinc-700">계약서가 없습니다</p>
           <p className="mt-1 text-sm text-zinc-400">
-            Upload your first contract to get started.
+            첫 번째 계약서를 업로드해 시작하세요.
           </p>
           <button
             onClick={() => setShowUpload(true)}
@@ -480,7 +480,7 @@ export default function ContractsPage() {
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
-            Upload contract
+            계약서 업로드
           </button>
         </div>
       )}
@@ -494,13 +494,13 @@ export default function ContractsPage() {
                 d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
           </div>
-          <p className="text-sm font-medium text-zinc-700">No contracts match your filters</p>
-          <p className="mt-1 text-sm text-zinc-400">Try adjusting your search or status filter.</p>
+          <p className="text-sm font-medium text-zinc-700">필터 조건에 맞는 계약서가 없습니다</p>
+          <p className="mt-1 text-sm text-zinc-400">검색어나 상태 필터를 조정해보세요.</p>
           <button
             onClick={clearFilters}
             className="cursor-pointer mt-4 text-sm font-medium text-zinc-700 underline underline-offset-2 hover:no-underline"
           >
-            Clear filters
+            필터 초기화
           </button>
         </div>
       )}
@@ -515,12 +515,12 @@ export default function ContractsPage() {
               checked={allVisibleSelected}
               onChange={toggleSelectAll}
               className="cursor-pointer h-4 w-4 rounded border-zinc-300 accent-zinc-900"
-              aria-label="Select all contracts"
+              aria-label="모든 계약서 선택"
             />
             <span className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
               {someSelected
-                ? `${selectedIds.size} selected`
-                : `${contracts.length} contract${contracts.length !== 1 ? "s" : ""}`}
+                ? `${selectedIds.size}개 선택됨`
+                : `총 ${contracts.length}건`}
             </span>
           </div>
 
@@ -586,7 +586,7 @@ export default function ContractsPage() {
                           : "flex-shrink-0 hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 bg-orange-50 text-orange-600 ring-orange-200"
                       }
                     >
-                      {expiryStatus === "expired" ? "Expired" : "Expires soon"}
+                      {expiryStatus === "expired" ? "만료됨" : "곧 만료"}
                     </span>
                   );
                 })()}
@@ -615,7 +615,7 @@ export default function ContractsPage() {
               <button
                 onClick={(e) => openDeleteDialog(e, c)}
                 className="cursor-pointer mr-4 flex-shrink-0 rounded-md p-1.5 text-zinc-300 opacity-0 group-hover:opacity-100 transition-all hover:bg-red-50 hover:text-red-500"
-                title="Delete contract"
+                title="계약서 삭제"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path
@@ -636,13 +636,13 @@ export default function ContractsPage() {
         <div className="fixed bottom-6 left-1/2 z-30 -translate-x-1/2 animate-slide-in">
           <div className="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white px-5 py-3 shadow-lg ring-1 ring-zinc-200">
             <span className="text-sm font-medium text-zinc-700">
-              {selectedIds.size} contract{selectedIds.size !== 1 ? "s" : ""} selected
+              {selectedIds.size}개 선택됨
             </span>
             <button
               onClick={() => setSelectedIds(new Set())}
               className="cursor-pointer text-xs text-zinc-400 transition-colors hover:text-zinc-600"
             >
-              Deselect all
+              선택 해제
             </button>
             <div className="h-4 w-px bg-zinc-200" />
             <button
@@ -653,7 +653,7 @@ export default function ContractsPage() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                   d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
               </svg>
-              Delete selected
+              선택 삭제
             </button>
           </div>
         </div>
@@ -670,10 +670,10 @@ export default function ContractsPage() {
             {loadMoreState === "loading" ? (
               <span className="flex items-center gap-2">
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600" />
-                Loading&hellip;
+                로딩 중&hellip;
               </span>
             ) : (
-              `Load more (${total - contracts.length} remaining)`
+              `더 보기 (${total - contracts.length}건 남음)`
             )}
           </button>
         </div>
@@ -688,12 +688,12 @@ export default function ContractsPage() {
           }
         >
           <div className="w-full max-w-sm animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
-            <h3 className="text-base font-semibold text-zinc-900">Delete contract?</h3>
+            <h3 className="text-base font-semibold text-zinc-900">계약서를 삭제할까요?</h3>
             <p className="mt-2 text-sm text-zinc-500">
               <span className="font-medium text-zinc-800">
                 &ldquo;{deleteDialog.contractTitle}&rdquo;
               </span>{" "}
-              will be permanently deleted. This cannot be undone.
+              이 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
             </p>
             <div className="mt-6 flex justify-end gap-2">
               <button
@@ -703,7 +703,7 @@ export default function ContractsPage() {
                 disabled={deleting}
                 className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:opacity-50"
               >
-                Cancel
+                취소
               </button>
               <button
                 onClick={handleConfirmDelete}
@@ -713,10 +713,10 @@ export default function ContractsPage() {
                 {deleting ? (
                   <span className="flex items-center gap-2">
                     <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-                    Deleting&hellip;
+                    삭제 중&hellip;
                   </span>
                 ) : (
-                  "Delete"
+                  "삭제"
                 )}
               </button>
             </div>
@@ -729,16 +729,16 @@ export default function ContractsPage() {
         <Modal onClose={() => !bulkDeleting && setBulkDeleteOpen(false)}>
           <div className="w-full max-w-sm animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
             <h3 className="text-base font-semibold text-zinc-900">
-              Delete {selectedIds.size} contract{selectedIds.size !== 1 ? "s" : ""}?
+              {selectedIds.size}개 계약서를 삭제할까요?
             </h3>
             <p className="mt-2 text-sm text-zinc-500">
-              This will permanently delete the selected contract{selectedIds.size !== 1 ? "s" : ""}.
-              This cannot be undone.
+              선택한 계약서가 영구적으로 삭제됩니다.
+              이 작업은 되돌릴 수 없습니다.
             </p>
             {bulkDeleting && (
               <div className="mt-4 space-y-2">
                 <div className="flex justify-between text-xs text-zinc-500">
-                  <span>Deleting&hellip;</span>
+                  <span>삭제 중&hellip;</span>
                   <span className="tabular-nums">
                     {bulkDeleteProgress.done} / {bulkDeleteProgress.total}
                   </span>
@@ -759,7 +759,7 @@ export default function ContractsPage() {
                 disabled={bulkDeleting}
                 className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:opacity-50"
               >
-                Cancel
+                취소
               </button>
               <button
                 onClick={handleBulkDelete}
@@ -769,10 +769,10 @@ export default function ContractsPage() {
                 {bulkDeleting ? (
                   <span className="flex items-center gap-2">
                     <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-                    Deleting&hellip;
+                    삭제 중&hellip;
                   </span>
                 ) : (
-                  `Delete ${selectedIds.size}`
+                  `${selectedIds.size}개 삭제`
                 )}
               </button>
             </div>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -10,10 +10,10 @@ import type { Contract, DashboardStats, ContractStatus } from "@/types";
 // ─── Status badge helpers (reusing contracts page colours) ─────────────────
 
 const STATUS_LABEL: Record<string, string> = {
-  uploaded: "Uploaded",
-  processing: "Processing",
-  ready: "Ready",
-  failed: "Failed",
+  uploaded: "업로드됨",
+  processing: "처리 중",
+  ready: "분석 완료",
+  failed: "실패",
 };
 
 const STATUS_COLOR: Record<string, string> = {
@@ -39,14 +39,14 @@ function ExpiryBadge({ expiresAt }: { expiresAt: string }) {
   if (days < 0) {
     return (
       <span className="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 ring-1 ring-red-200">
-        Expired
+        만료됨
       </span>
     );
   }
   if (days === 0) {
     return (
       <span className="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 ring-1 ring-red-200">
-        Expires today
+        오늘 만료
       </span>
     );
   }
@@ -112,7 +112,7 @@ function RiskBar({ high, medium, low }: RiskBarProps) {
   if (total === 0) {
     return (
       <p className="text-sm text-zinc-400">
-        No completed analyses yet.
+        완료된 분석이 없습니다.
       </p>
     );
   }
@@ -149,15 +149,15 @@ function RiskBar({ high, medium, low }: RiskBarProps) {
       <div className="flex flex-wrap gap-4 text-xs">
         <span className="flex items-center gap-1.5 text-zinc-600">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-red-500" />
-          High &mdash; {high} ({highPct}%)
+          높음 &mdash; {high} ({highPct}%)
         </span>
         <span className="flex items-center gap-1.5 text-zinc-600">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-amber-400" />
-          Medium &mdash; {medium} ({medPct}%)
+          중간 &mdash; {medium} ({medPct}%)
         </span>
         <span className="flex items-center gap-1.5 text-zinc-600">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-green-400" />
-          Low &mdash; {low} ({lowPct}%)
+          낮음 &mdash; {low} ({lowPct}%)
         </span>
       </div>
     </div>
@@ -179,7 +179,7 @@ function ExpiryBucketsWidget({ days30, days60, days90 }: ExpiryBucketsWidgetProp
 
   const buckets = [
     {
-      label: "Within 30 days",
+      label: "30일 이내",
       count: days30,
       barClass: "bg-red-500",
       textClass: "text-red-700",
@@ -187,7 +187,7 @@ function ExpiryBucketsWidget({ days30, days60, days90 }: ExpiryBucketsWidgetProp
       ringClass: "ring-red-200",
     },
     {
-      label: "31 – 60 days",
+      label: "31 – 60일",
       count: between30and60,
       barClass: "bg-amber-400",
       textClass: "text-amber-700",
@@ -195,7 +195,7 @@ function ExpiryBucketsWidget({ days30, days60, days90 }: ExpiryBucketsWidgetProp
       ringClass: "ring-amber-200",
     },
     {
-      label: "61 – 90 days",
+      label: "61 – 90일",
       count: between60and90,
       barClass: "bg-yellow-300",
       textClass: "text-yellow-700",
@@ -209,7 +209,7 @@ function ExpiryBucketsWidget({ days30, days60, days90 }: ExpiryBucketsWidgetProp
   if (days90 === 0) {
     return (
       <p className="text-sm text-zinc-400">
-        No contracts expiring within 90 days.
+        90일 이내 만료되는 계약서가 없습니다.
       </p>
     );
   }
@@ -239,7 +239,7 @@ function ExpiryBucketsWidget({ days30, days60, days90 }: ExpiryBucketsWidgetProp
         </div>
       ))}
       <p className="mt-1 text-xs text-zinc-400">
-        {days90} total expiring within 90 days
+        90일 이내 만료 예정 총 {days90}건
       </p>
     </div>
   );
@@ -266,7 +266,7 @@ export default function DashboardPage() {
       const data = await api.getDashboardStats(orgId);
       setStats(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load dashboard");
+      setError(err instanceof Error ? err.message : "대시보드를 불러오지 못했습니다.");
     } finally {
       setLoading(false);
     }
@@ -304,7 +304,7 @@ export default function DashboardPage() {
       {/* Page header */}
       <div className="mb-8 flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-900">Dashboard</h1>
+          <h1 className="text-2xl font-semibold text-zinc-900">대시보드</h1>
           {user?.organizationName && (
             <p className="mt-0.5 text-sm text-zinc-500">{user.organizationName}</p>
           )}
@@ -313,7 +313,7 @@ export default function DashboardPage() {
           href="/contracts"
           className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
         >
-          View Contracts
+          계약서 보기
         </Link>
       </div>
 
@@ -325,7 +325,7 @@ export default function DashboardPage() {
             onClick={fetchStats}
             className="underline hover:no-underline"
           >
-            Retry
+            다시 시도
           </button>
         </div>
       )}
@@ -333,7 +333,7 @@ export default function DashboardPage() {
       {/* Contract status cards */}
       <section className="mb-8">
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-400">
-          Contract Overview
+          계약서 현황
         </h2>
         {loading ? (
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
@@ -343,28 +343,28 @@ export default function DashboardPage() {
           </div>
         ) : (
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-            <StatCard label="Total" value={stats?.totalContracts ?? 0} />
+            <StatCard label="전체" value={stats?.totalContracts ?? 0} />
             <StatCard
-              label="Ready"
+              label="분석 완료"
               value={stats?.readyContracts ?? 0}
               accent="text-green-600"
             />
             <StatCard
-              label="Processing"
+              label="처리 중"
               value={stats?.processingContracts ?? 0}
               accent="text-amber-600"
             />
             <StatCard
-              label="Uploaded"
+              label="업로드됨"
               value={stats?.uploadedContracts ?? 0}
             />
             <StatCard
-              label="Failed"
+              label="실패"
               value={stats?.failedContracts ?? 0}
               accent="text-red-600"
             />
             <StatCard
-              label="Expiring (30d)"
+              label="만료 임박 (30일)"
               value={stats?.expiryBuckets?.days30 ?? stats?.expiringSoon ?? 0}
               accent={
                 (stats?.expiryBuckets?.days30 ?? stats?.expiringSoon ?? 0) > 0
@@ -382,11 +382,11 @@ export default function DashboardPage() {
         <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
           <div className="mb-4 flex items-center justify-between">
             <h2 className="text-sm font-semibold text-zinc-800">
-              Risk Distribution
+              리스크 분포
             </h2>
             {!loading && stats && (
               <span className="text-xs text-zinc-400">
-                {stats.recentAnalyses} analyses (last 30 days)
+                최근 30일 분석 {stats.recentAnalyses}건
               </span>
             )}
           </div>
@@ -408,13 +408,13 @@ export default function DashboardPage() {
         <section className="rounded-xl border border-zinc-200 bg-white shadow-sm">
           <div className="flex items-center justify-between border-b border-zinc-100 px-5 py-4">
             <h2 className="text-sm font-semibold text-zinc-800">
-              Recent Contracts
+              최근 계약서
             </h2>
             <Link
               href="/contracts"
               className="text-xs font-medium text-zinc-500 hover:text-zinc-800"
             >
-              View all
+              전체 보기
             </Link>
           </div>
 
@@ -439,9 +439,9 @@ export default function DashboardPage() {
                   d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                 />
               </svg>
-              No contracts yet.{" "}
+              계약서가 없습니다.{" "}
               <Link href="/contracts" className="underline hover:no-underline">
-                Upload one
+                업로드하기
               </Link>
             </div>
           ) : (
@@ -479,9 +479,9 @@ export default function DashboardPage() {
         <section className="rounded-xl border border-zinc-200 bg-white shadow-sm">
           <div className="flex items-center justify-between border-b border-zinc-100 px-5 py-4">
             <h2 className="text-sm font-semibold text-zinc-800">
-              Expiring Soon
+              만료 임박
             </h2>
-            <span className="text-xs text-zinc-400">Next 30 days</span>
+            <span className="text-xs text-zinc-400">향후 30일</span>
           </div>
 
           {expiringLoading ? (
@@ -505,7 +505,7 @@ export default function DashboardPage() {
                   d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
                 />
               </svg>
-              No contracts expiring soon.
+              곧 만료되는 계약서가 없습니다.
             </div>
           ) : (
             <ul className="divide-y divide-zinc-50">
@@ -533,13 +533,13 @@ export default function DashboardPage() {
       <section className="mt-6 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-sm font-semibold text-zinc-800">
-            Expiry Timeline
+            만료 일정
           </h2>
           <Link
             href="/contracts?status=ready"
             className="text-xs font-medium text-zinc-500 hover:text-zinc-800"
           >
-            Manage contracts
+            계약서 관리
           </Link>
         </div>
         {loading ? (
@@ -559,7 +559,7 @@ export default function DashboardPage() {
             days90={stats.expiryBuckets.days90}
           />
         ) : (
-          <p className="text-sm text-zinc-400">No expiry data available.</p>
+          <p className="text-sm text-zinc-400">만료 데이터가 없습니다.</p>
         )}
       </section>
     </div>

--- a/src/app/(app)/error.tsx
+++ b/src/app/(app)/error.tsx
@@ -33,13 +33,13 @@ export default function AppError({ error, reset }: ErrorProps) {
 
       <div className="space-y-1.5">
         <h2 className="text-base font-semibold text-zinc-900">
-          Something went wrong
+          오류가 발생했습니다
         </h2>
         <p className="text-sm text-zinc-500">
-          An unexpected error occurred. Please try again.
+          예상치 못한 오류가 발생했습니다. 다시 시도해주세요.
         </p>
         {error.digest && (
-          <p className="text-xs text-zinc-400">Error ID: {error.digest}</p>
+          <p className="text-xs text-zinc-400">오류 ID: {error.digest}</p>
         )}
       </div>
 
@@ -47,7 +47,7 @@ export default function AppError({ error, reset }: ErrorProps) {
         onClick={reset}
         className="rounded-lg bg-zinc-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
       >
-        Try again
+        다시 시도
       </button>
     </div>
   );

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -90,10 +90,10 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             </Link>
 
             <nav className="flex items-center gap-5">
-              <NavLink href="/dashboard">Dashboard</NavLink>
-              <NavLink href="/contracts">Contracts</NavLink>
+              <NavLink href="/dashboard">대시보드</NavLink>
+              <NavLink href="/contracts">계약서</NavLink>
               {user?.permissions?.includes("audit:read") && (
-                <NavLink href="/audit-logs">Audit Log</NavLink>
+                <NavLink href="/audit-logs">감사 로그</NavLink>
               )}
             </nav>
           </div>
@@ -113,7 +113,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 href="/settings"
                 className="cursor-pointer rounded-md px-2.5 py-1.5 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900"
               >
-                <span className="hidden sm:inline">Settings</span>
+                <span className="hidden sm:inline">설정</span>
                 <svg
                   className="h-4 w-4 sm:hidden"
                   fill="none"
@@ -138,7 +138,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 onClick={handleLogout}
                 className="cursor-pointer rounded-md px-2.5 py-1.5 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900"
               >
-                <span className="hidden sm:inline">Sign out</span>
+                <span className="hidden sm:inline">로그아웃</span>
                 <svg
                   className="h-4 w-4 sm:hidden"
                   fill="none"

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -41,8 +41,8 @@ export default function SettingsLayout({
       {/* Sticky tab bar */}
       <div className="sticky top-14 z-20 border-b border-zinc-200 bg-white">
         <div className="mx-auto flex max-w-3xl gap-6 px-4 pt-5 sm:px-6">
-          <SettingsTab href="/settings">Account</SettingsTab>
-          <SettingsTab href="/settings/organization">Organization</SettingsTab>
+          <SettingsTab href="/settings">계정</SettingsTab>
+          <SettingsTab href="/settings/organization">조직</SettingsTab>
         </div>
       </div>
 

--- a/src/app/(app)/settings/organization/page.tsx
+++ b/src/app/(app)/settings/organization/page.tsx
@@ -35,10 +35,10 @@ function InviteForm({ orgId, onInvited, onCancel }: InviteFormProps) {
     setInviting(true);
     try {
       await api.inviteMember(orgId, email.trim(), role);
-      toast("success", `${email.trim()} added to organization.`);
+      toast("success", `${email.trim()} 을(를) 조직에 추가했습니다.`);
       onInvited();
     } catch (err: unknown) {
-      toast("error", getErrorMessage(err, "Failed to invite member."));
+      toast("error", getErrorMessage(err, "멤버 초대에 실패했습니다."));
     } finally {
       setInviting(false);
     }
@@ -49,7 +49,7 @@ function InviteForm({ orgId, onInvited, onCancel }: InviteFormProps) {
       onSubmit={handleSubmit}
       className="mt-4 rounded-lg border border-zinc-200 bg-zinc-50 p-4 space-y-3"
     >
-      <p className="text-sm font-medium text-zinc-900">Invite a new member</p>
+      <p className="text-sm font-medium text-zinc-900">새 멤버 초대</p>
       <div className="flex flex-col gap-3 sm:flex-row">
         <input
           type="email"
@@ -65,13 +65,13 @@ function InviteForm({ orgId, onInvited, onCancel }: InviteFormProps) {
           onChange={(e) => setRole(e.target.value)}
           className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-900"
         >
-          <option value="member">Member</option>
-          <option value="reviewer">Reviewer</option>
-          <option value="admin">Admin</option>
+          <option value="member">멤버</option>
+          <option value="reviewer">검토자</option>
+          <option value="admin">관리자</option>
         </select>
       </div>
       <p className="text-xs text-zinc-400">
-        The user must already have a SignSafe account.
+        해당 사용자가 이미 SignSafe 계정을 보유하고 있어야 합니다.
       </p>
       <div className="flex justify-end gap-2">
         <button
@@ -79,7 +79,7 @@ function InviteForm({ orgId, onInvited, onCancel }: InviteFormProps) {
           onClick={onCancel}
           className="rounded-lg border border-zinc-200 px-3 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100 transition-colors"
         >
-          Cancel
+          취소
         </button>
         <button
           type="submit"
@@ -87,7 +87,7 @@ function InviteForm({ orgId, onInvited, onCancel }: InviteFormProps) {
           className={primaryBtnCls}
         >
           {inviting && <Spinner className="h-3.5 w-3.5" />}
-          {inviting ? "Inviting…" : "Send invite"}
+          {inviting ? "초대 중…" : "초대 발송"}
         </button>
       </div>
     </form>
@@ -116,21 +116,21 @@ export default function OrganizationSettingsPage() {
         setOrgName(org.name);
         setOrgPlan(org.plan);
       })
-      .catch(() => toast("error", "Failed to load organization."))
+      .catch(() => toast("error", "조직 정보를 불러오지 못했습니다."))
       .finally(() => setOrgLoading(false));
   }, [orgId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleSaveOrg() {
     if (!orgName.trim()) {
-      toast("error", "Organization name cannot be empty.");
+      toast("error", "조직 이름을 입력해주세요.");
       return;
     }
     setOrgSaving(true);
     try {
       await api.updateOrganization(orgId, orgName.trim());
-      toast("success", "Organization name updated.");
+      toast("success", "조직 이름이 업데이트되었습니다.");
     } catch (err: unknown) {
-      toast("error", getErrorMessage(err, "Failed to update organization."));
+      toast("error", getErrorMessage(err, "조직 업데이트에 실패했습니다."));
     } finally {
       setOrgSaving(false);
     }
@@ -150,7 +150,7 @@ export default function OrganizationSettingsPage() {
     api
       .listMembers(orgId)
       .then((res) => setMembers(res.members))
-      .catch(() => toast("error", "Failed to load members."))
+      .catch(() => toast("error", "멤버 목록을 불러오지 못했습니다."))
       .finally(() => setMembersLoading(false));
   };
 
@@ -163,9 +163,9 @@ export default function OrganizationSettingsPage() {
     try {
       await api.removeMember(orgId, targetUserId);
       setMembers((prev) => prev.filter((m) => m.userId !== targetUserId));
-      toast("success", "Member removed.");
+      toast("success", "멤버가 제거되었습니다.");
     } catch (err: unknown) {
-      toast("error", getErrorMessage(err, "Failed to remove member."));
+      toast("error", getErrorMessage(err, "멤버 제거에 실패했습니다."));
     } finally {
       setRemoving(null);
     }
@@ -181,9 +181,9 @@ export default function OrganizationSettingsPage() {
       setMembers((prev) =>
         prev.map((m) => (m.userId === targetUserId ? { ...m, role: newRole } : m))
       );
-      toast("success", "Role updated.");
+      toast("success", "역할이 업데이트되었습니다.");
     } catch (err: unknown) {
-      toast("error", getErrorMessage(err, "Failed to update role."));
+      toast("error", getErrorMessage(err, "역할 업데이트에 실패했습니다."));
     } finally {
       setUpdatingRole(null);
     }
@@ -193,9 +193,9 @@ export default function OrganizationSettingsPage() {
     setResending(targetEmail);
     try {
       await api.inviteMember(orgId, targetEmail);
-      toast("success", `Invitation re-sent to ${targetEmail}.`);
+      toast("success", `${targetEmail}에게 초대를 재발송했습니다.`);
     } catch (err: unknown) {
-      toast("error", getErrorMessage(err, "Failed to re-send invitation."));
+      toast("error", getErrorMessage(err, "초대 재발송에 실패했습니다."));
     } finally {
       setResending(null);
     }
@@ -204,11 +204,11 @@ export default function OrganizationSettingsPage() {
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6 sm:py-10 space-y-8">
       <div>
-        <h1 className="text-xl font-semibold text-zinc-900">Organization</h1>
+        <h1 className="text-xl font-semibold text-zinc-900">조직</h1>
         <p className="mt-1 text-sm text-zinc-500">
           {isAdmin
-            ? "Manage your organization's settings and members."
-            : "View your organization's settings. Contact an admin to make changes."}
+            ? "조직의 설정과 멤버를 관리합니다."
+            : "조직 설정을 확인합니다. 변경이 필요하면 관리자에게 문의하세요."}
         </p>
       </div>
 
@@ -228,15 +228,15 @@ export default function OrganizationSettingsPage() {
             />
           </svg>
           <p className="text-sm text-zinc-500">
-            You have read-only access. Only admins can modify organization settings.
+            읽기 전용 접근 권한입니다. 관리자만 조직 설정을 변경할 수 있습니다.
           </p>
         </div>
       )}
 
       {/* Organization info */}
       <Section
-        title="Organization Info"
-        description="The display name used throughout SignSafe."
+        title="조직 정보"
+        description="SignSafe 전체에서 표시되는 조직 이름입니다."
       >
         {orgLoading ? (
           <div className="flex items-center justify-center py-8">
@@ -244,7 +244,7 @@ export default function OrganizationSettingsPage() {
           </div>
         ) : (
           <div className="space-y-4">
-            <Field label="Organization name">
+            <Field label="조직 이름">
               <input
                 type="text"
                 value={orgName}
@@ -254,7 +254,7 @@ export default function OrganizationSettingsPage() {
               />
             </Field>
             <div className="flex items-center gap-2">
-              <span className="text-sm text-zinc-500">Plan</span>
+              <span className="text-sm text-zinc-500">플랜</span>
               <span className="inline-flex items-center rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-0.5 text-xs font-medium text-zinc-700 capitalize">
                 {orgPlan || "free"}
               </span>
@@ -263,7 +263,7 @@ export default function OrganizationSettingsPage() {
               <div className="flex justify-end pt-1">
                 <button onClick={handleSaveOrg} disabled={orgSaving} className={primaryBtnCls}>
                   {orgSaving && <Spinner className="h-3.5 w-3.5" />}
-                  {orgSaving ? "Saving…" : "Save changes"}
+                  {orgSaving ? "저장 중…" : "변경 사항 저장"}
                 </button>
               </div>
             )}
@@ -273,15 +273,15 @@ export default function OrganizationSettingsPage() {
 
       {/* Members */}
       <Section
-        title="Members"
-        description={`${members.length} member${members.length !== 1 ? "s" : ""} in this organization.`}
+        title="멤버"
+        description={`이 조직의 멤버 ${members.length}명`}
       >
         <div className="space-y-1">
           {!membersLoading && members.length > 0 && (
             <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-4 px-0 pb-2 text-xs font-medium text-zinc-400 uppercase tracking-wide">
-              <span>Member</span>
-              <span className="hidden sm:block">Role</span>
-              <span className="hidden sm:block">Joined</span>
+              <span>멤버</span>
+              <span className="hidden sm:block">역할</span>
+              <span className="hidden sm:block">가입일</span>
               {isAdmin && <span />}
             </div>
           )}
@@ -291,7 +291,7 @@ export default function OrganizationSettingsPage() {
               <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-600" />
             </div>
           ) : members.length === 0 ? (
-            <p className="py-6 text-center text-sm text-zinc-400">No members found.</p>
+            <p className="py-6 text-center text-sm text-zinc-400">멤버가 없습니다.</p>
           ) : (
             <ul className="divide-y divide-zinc-100">
               {members.map((m) => {
@@ -309,14 +309,14 @@ export default function OrganizationSettingsPage() {
                         <p className="truncate text-sm font-medium text-zinc-900">
                           {m.fullName}
                           {isSelf && (
-                            <span className="ml-1.5 text-xs text-zinc-400 font-normal">(you)</span>
+                            <span className="ml-1.5 text-xs text-zinc-400 font-normal">(나)</span>
                           )}
                         </p>
                         <p className="truncate text-xs text-zinc-400">
                           {m.email}
                           {!m.emailVerified && (
                             <span className="ml-1.5 inline-flex items-center rounded-full bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
-                              Unverified
+                              미인증
                             </span>
                           )}
                         </p>
@@ -336,9 +336,9 @@ export default function OrganizationSettingsPage() {
                           disabled={updatingRole === m.userId}
                           className="rounded-lg border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs text-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-900 disabled:opacity-40 capitalize"
                         >
-                          <option value="member">Member</option>
-                          <option value="reviewer">Reviewer</option>
-                          <option value="admin">Admin</option>
+                          <option value="member">멤버</option>
+                          <option value="reviewer">검토자</option>
+                          <option value="admin">관리자</option>
                         </select>
                       ) : (
                         <RoleBadge role={m.role} />
@@ -355,9 +355,9 @@ export default function OrganizationSettingsPage() {
                           onClick={() => handleResendInvite(m.email)}
                           disabled={resending === m.email}
                           className="text-xs text-zinc-500 hover:text-indigo-600 transition-colors disabled:opacity-40 whitespace-nowrap"
-                          title="Re-send invitation email"
+                          title="초대 이메일 재발송"
                         >
-                          {resending === m.email ? "Sending…" : "Resend invite"}
+                          {resending === m.email ? "발송 중…" : "초대 재발송"}
                         </button>
                       )}
                       {isAdmin && !isSelf ? (
@@ -366,7 +366,7 @@ export default function OrganizationSettingsPage() {
                           disabled={removing === m.userId}
                           className="text-xs text-zinc-400 hover:text-red-600 transition-colors disabled:opacity-40 whitespace-nowrap"
                         >
-                          {removing === m.userId ? "Removing…" : "Remove"}
+                          {removing === m.userId ? "제거 중…" : "제거"}
                         </button>
                       ) : null}
                     </div>
@@ -406,7 +406,7 @@ export default function OrganizationSettingsPage() {
                         d="M12 4v16m8-8H4"
                       />
                     </svg>
-                    Invite member
+                    멤버 초대
                   </button>
                 </div>
               )}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -26,7 +26,7 @@ export default function AccountSettingsPage() {
 
   async function handleSaveProfile() {
     if (!profileName.trim()) {
-      toast("error", "Name cannot be empty.");
+      toast("error", "이름을 입력해주세요.");
       return;
     }
     setProfileSaving(true);
@@ -35,9 +35,9 @@ export default function AccountSettingsPage() {
       if (user) {
         setAuth(accessToken ?? "", { ...user, fullName: updated.fullName });
       }
-      toast("success", "Profile updated.");
+      toast("success", "프로필이 업데이트되었습니다.");
     } catch (err: unknown) {
-      toast("error", getErrorMessage(err, "Failed to update profile."));
+      toast("error", getErrorMessage(err, "프로필 업데이트에 실패했습니다."));
     } finally {
       setProfileSaving(false);
     }
@@ -52,11 +52,11 @@ export default function AccountSettingsPage() {
 
   function validatePasswords(): string | null {
     if (!currentPassword || !newPassword || !confirmPassword)
-      return "All password fields are required.";
+      return "모든 비밀번호 필드를 입력해주세요.";
     if (newPassword.length < 8)
-      return "New password must be at least 8 characters.";
+      return "새 비밀번호는 최소 8자 이상이어야 합니다.";
     if (newPassword !== confirmPassword)
-      return "New passwords do not match.";
+      return "새 비밀번호가 일치하지 않습니다.";
     return null;
   }
 
@@ -81,9 +81,9 @@ export default function AccountSettingsPage() {
       setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
-      toast("success", "Password changed successfully.");
+      toast("success", "비밀번호가 변경되었습니다.");
     } catch (err: unknown) {
-      const msg = getErrorMessage(err, "Failed to change password.");
+      const msg = getErrorMessage(err, "비밀번호 변경에 실패했습니다.");
       setPasswordError(msg);
       toast("error", msg);
     } finally {
@@ -100,7 +100,7 @@ export default function AccountSettingsPage() {
     api
       .listMyOrganizations()
       .then(setOrgs)
-      .catch(() => toast("error", "Failed to load organizations."))
+      .catch(() => toast("error", "조직 목록을 불러오지 못했습니다."))
       .finally(() => setOrgsLoading(false));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -113,19 +113,19 @@ export default function AccountSettingsPage() {
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6 sm:py-10 space-y-8">
       <div>
-        <h1 className="text-xl font-semibold text-zinc-900">Account</h1>
+        <h1 className="text-xl font-semibold text-zinc-900">계정</h1>
         <p className="mt-1 text-sm text-zinc-500">
-          Manage your personal profile and security settings.
+          개인 프로필 및 보안 설정을 관리합니다.
         </p>
       </div>
 
       {/* Profile */}
       <Section
-        title="Profile"
-        description="Update the name that appears across SignSafe."
+        title="프로필"
+        description="SignSafe 전체에 표시되는 이름을 업데이트합니다."
       >
         <div className="space-y-4">
-          <Field label="Full name">
+          <Field label="이름">
             <input
               type="text"
               value={profileName}
@@ -135,7 +135,7 @@ export default function AccountSettingsPage() {
             />
           </Field>
           <div className="flex items-center gap-4">
-            <Field label="Email">
+            <Field label="이메일">
               <p className="py-2 text-sm text-zinc-600">{user?.email}</p>
             </Field>
           </div>
@@ -146,7 +146,7 @@ export default function AccountSettingsPage() {
               className={primaryBtnCls}
             >
               {profileSaving && <Spinner className="h-3.5 w-3.5" />}
-              {profileSaving ? "Saving…" : "Save changes"}
+              {profileSaving ? "저장 중…" : "변경 사항 저장"}
             </button>
           </div>
         </div>
@@ -154,11 +154,11 @@ export default function AccountSettingsPage() {
 
       {/* Password */}
       <Section
-        title="Password"
-        description="Use a strong password you don't use elsewhere."
+        title="비밀번호"
+        description="다른 곳에서 사용하지 않는 강력한 비밀번호를 사용하세요."
       >
         <div className="space-y-4">
-          <Field label="Current password">
+          <Field label="현재 비밀번호">
             <input
               type="password"
               value={currentPassword}
@@ -168,7 +168,7 @@ export default function AccountSettingsPage() {
             />
           </Field>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <Field label="New password">
+            <Field label="새 비밀번호">
               <input
                 type="password"
                 value={newPassword}
@@ -177,7 +177,7 @@ export default function AccountSettingsPage() {
                 className={inputCls}
               />
             </Field>
-            <Field label="Confirm new password">
+            <Field label="새 비밀번호 확인">
               <input
                 type="password"
                 value={confirmPassword}
@@ -197,7 +197,7 @@ export default function AccountSettingsPage() {
               className={primaryBtnCls}
             >
               {passwordSaving && <Spinner className="h-3.5 w-3.5" />}
-              {passwordSaving ? "Updating…" : "Update password"}
+              {passwordSaving ? "변경 중…" : "비밀번호 변경"}
             </button>
           </div>
         </div>
@@ -205,8 +205,8 @@ export default function AccountSettingsPage() {
 
       {/* My organizations */}
       <Section
-        title="Organizations"
-        description="Organizations you belong to. Click 'Settings' to manage an organization."
+        title="조직"
+        description="소속된 조직입니다. '설정'을 클릭하여 조직을 관리하세요."
       >
         {orgsLoading ? (
           <div className="flex items-center justify-center py-8">
@@ -214,7 +214,7 @@ export default function AccountSettingsPage() {
           </div>
         ) : orgs.length === 0 ? (
           <p className="py-4 text-center text-sm text-zinc-400">
-            You are not a member of any organization.
+            소속된 조직이 없습니다.
           </p>
         ) : (
           <ul className="divide-y divide-zinc-100">
@@ -229,7 +229,7 @@ export default function AccountSettingsPage() {
                   </div>
                   <div className="min-w-0">
                     <p className="truncate text-sm font-medium text-zinc-900">{org.name}</p>
-                    <p className="text-xs text-zinc-400 capitalize">{org.plan} plan</p>
+                    <p className="text-xs text-zinc-400 capitalize">{org.plan} 플랜</p>
                   </div>
                 </div>
                 <div className="flex flex-shrink-0 items-center gap-3">
@@ -239,7 +239,7 @@ export default function AccountSettingsPage() {
                     onClick={() => handleGoToOrgSettings(org)}
                     className="rounded-lg border border-zinc-200 px-3 py-1.5 text-xs font-medium text-zinc-600 hover:bg-zinc-50 transition-colors"
                   >
-                    Settings
+                    설정
                   </Link>
                 </div>
               </li>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -20,7 +20,7 @@ export default function ForgotPasswordPage() {
       await api.forgotPassword(email);
       setState("success");
     } catch {
-      setError("Something went wrong. Please try again.");
+      setError("오류가 발생했습니다. 다시 시도해주세요.");
       setState("error");
     }
   }
@@ -37,18 +37,17 @@ export default function ForgotPasswordPage() {
           </svg>
         </div>
         <div>
-          <h2 className="text-base font-semibold text-zinc-900">Check your inbox</h2>
+          <h2 className="text-base font-semibold text-zinc-900">받은 편지함을 확인하세요</h2>
           <p className="mt-2 text-sm text-zinc-500">
-            If an account exists for{" "}
-            <span className="font-medium text-zinc-900">{email}</span>, we&apos;ve
-            sent a password reset link.
+            <span className="font-medium text-zinc-900">{email}</span>에 해당하는
+            계정이 존재하면 비밀번호 재설정 링크를 발송했습니다.
           </p>
         </div>
         <Link
           href="/login"
           className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Back to sign in
+          로그인으로 돌아가기
         </Link>
       </div>
     );
@@ -57,9 +56,9 @@ export default function ForgotPasswordPage() {
   return (
     <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
       <div className="mb-7 text-center">
-        <h2 className="text-lg font-semibold text-zinc-900">Reset your password</h2>
+        <h2 className="text-lg font-semibold text-zinc-900">비밀번호 재설정</h2>
         <p className="mt-1 text-sm text-zinc-500">
-          Enter your email and we&apos;ll send you a reset link.
+          이메일을 입력하시면 재설정 링크를 보내드립니다.
         </p>
       </div>
 
@@ -72,7 +71,7 @@ export default function ForgotPasswordPage() {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-zinc-700">
-            Email
+            이메일
           </label>
           <input
             id="email"
@@ -94,21 +93,21 @@ export default function ForgotPasswordPage() {
           {state === "loading" ? (
             <span className="flex items-center justify-center gap-2">
               <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-              Sending…
+              발송 중…
             </span>
           ) : (
-            "Send reset link"
+            "재설정 링크 보내기"
           )}
         </button>
       </form>
 
       <p className="mt-6 text-center text-sm text-zinc-500">
-        Remember your password?{" "}
+        비밀번호가 기억나시나요?{" "}
         <Link
           href="/login"
           className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Sign in
+          로그인
         </Link>
       </p>
     </div>

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -35,7 +35,7 @@ export default function AuthLayout({
             SignSafe
           </h1>
           <p className="mt-1.5 text-sm text-zinc-500">
-            AI-powered contract risk analysis
+            AI 기반 계약서 리스크 분석
           </p>
         </div>
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -73,8 +73,8 @@ export default function LoginPage() {
   return (
     <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
       <div className="mb-7 text-center">
-        <h2 className="text-lg font-semibold text-zinc-900">Welcome back</h2>
-        <p className="mt-1 text-sm text-zinc-500">Sign in to your account</p>
+        <h2 className="text-lg font-semibold text-zinc-900">다시 오셨군요</h2>
+        <p className="mt-1 text-sm text-zinc-500">계정에 로그인하세요</p>
       </div>
 
       {formState.error && (
@@ -107,7 +107,7 @@ export default function LoginPage() {
             htmlFor="email"
             className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
-            Email
+            이메일
           </label>
           <input
             id="email"
@@ -127,13 +127,13 @@ export default function LoginPage() {
               htmlFor="password"
               className="text-sm font-medium text-zinc-700"
             >
-              Password
+              비밀번호
             </label>
             <Link
               href="/forgot-password"
               className="text-xs text-zinc-400 transition-colors hover:text-zinc-700"
             >
-              Forgot password?
+              비밀번호를 잊으셨나요?
             </Link>
           </div>
           <input
@@ -156,21 +156,21 @@ export default function LoginPage() {
           {formState.status === "loading" ? (
             <span className="flex items-center justify-center gap-2">
               <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-              Signing in…
+              로그인 중…
             </span>
           ) : (
-            "Sign in"
+            "로그인"
           )}
         </button>
       </form>
 
       <p className="mt-6 text-center text-sm text-zinc-500">
-        No account?{" "}
+        계정이 없으신가요?{" "}
         <Link
           href="/signup"
           className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Create one
+          회원가입
         </Link>
       </p>
     </div>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -25,12 +25,12 @@ function ResetPasswordForm() {
     setError(null);
 
     if (newPassword !== confirmPassword) {
-      setError("Passwords do not match.");
+      setError("비밀번호가 일치하지 않습니다.");
       return;
     }
 
     if (newPassword.length < 8) {
-      setError("Password must be at least 8 characters.");
+      setError("비밀번호는 최소 8자 이상이어야 합니다.");
       return;
     }
 
@@ -41,7 +41,7 @@ function ResetPasswordForm() {
       setState("success");
       setTimeout(() => router.push("/login"), 2000);
     } catch {
-      setError("This link is invalid or has expired. Please request a new one.");
+      setError("링크가 유효하지 않거나 만료되었습니다. 새 링크를 요청해주세요.");
       setState("error");
     }
   }
@@ -52,15 +52,15 @@ function ResetPasswordForm() {
   if (state === "missing-token") {
     return (
       <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
-        <h2 className="text-base font-semibold text-zinc-900">Invalid link</h2>
+        <h2 className="text-base font-semibold text-zinc-900">유효하지 않은 링크</h2>
         <p className="text-sm text-zinc-500">
-          This password reset link is missing a token.
+          비밀번호 재설정 링크에 토큰이 없습니다.
         </p>
         <Link
           href="/forgot-password"
           className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Request a new reset link
+          새 재설정 링크 요청
         </Link>
       </div>
     );
@@ -85,16 +85,16 @@ function ResetPasswordForm() {
           </svg>
         </div>
         <div>
-          <h2 className="text-base font-semibold text-zinc-900">Password updated</h2>
+          <h2 className="text-base font-semibold text-zinc-900">비밀번호 변경 완료</h2>
           <p className="mt-2 text-sm text-zinc-500">
-            Your password has been reset. Redirecting to sign in…
+            비밀번호가 재설정되었습니다. 로그인 페이지로 이동합니다…
           </p>
         </div>
         <Link
           href="/login"
           className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Go to sign in
+          로그인으로 이동
         </Link>
       </div>
     );
@@ -103,8 +103,8 @@ function ResetPasswordForm() {
   return (
     <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
       <div className="mb-7 text-center">
-        <h2 className="text-lg font-semibold text-zinc-900">Set new password</h2>
-        <p className="mt-1 text-sm text-zinc-500">Enter your new password below.</p>
+        <h2 className="text-lg font-semibold text-zinc-900">새 비밀번호 설정</h2>
+        <p className="mt-1 text-sm text-zinc-500">새 비밀번호를 입력해주세요.</p>
       </div>
 
       {state === "error" && error && (
@@ -119,7 +119,7 @@ function ResetPasswordForm() {
             htmlFor="new-password"
             className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
-            New password
+            새 비밀번호
           </label>
           <input
             id="new-password"
@@ -130,7 +130,7 @@ function ResetPasswordForm() {
             value={newPassword}
             onChange={(e) => setNewPassword(e.target.value)}
             className={inputCls}
-            placeholder="Min. 8 characters"
+            placeholder="최소 8자 이상"
           />
         </div>
 
@@ -139,7 +139,7 @@ function ResetPasswordForm() {
             htmlFor="confirm-password"
             className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
-            Confirm password
+            비밀번호 확인
           </label>
           <input
             id="confirm-password"
@@ -149,10 +149,10 @@ function ResetPasswordForm() {
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
             className={inputCls}
-            placeholder="Repeat password"
+            placeholder="비밀번호 재입력"
           />
           {confirmPassword.length > 0 && newPassword !== confirmPassword && (
-            <p className="mt-1.5 text-xs text-red-600">Passwords do not match.</p>
+            <p className="mt-1.5 text-xs text-red-600">비밀번호가 일치하지 않습니다.</p>
           )}
         </div>
 
@@ -168,21 +168,21 @@ function ResetPasswordForm() {
           {state === "loading" ? (
             <span className="flex items-center justify-center gap-2">
               <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-              Updating…
+              변경 중…
             </span>
           ) : (
-            "Reset password"
+            "비밀번호 재설정"
           )}
         </button>
       </form>
 
       <p className="mt-6 text-center text-sm text-zinc-500">
-        Remember your password?{" "}
+        비밀번호가 기억나시나요?{" "}
         <Link
           href="/login"
           className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Sign in
+          로그인
         </Link>
       </p>
     </div>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -28,7 +28,7 @@ export default function SignupPage() {
     if (!agreed) {
       setFormState({
         status: "error",
-        error: "You must agree to the terms of service.",
+        error: "이용약관에 동의해야 합니다.",
       });
       return;
     }
@@ -42,7 +42,7 @@ export default function SignupPage() {
       const message =
         err instanceof Error
           ? err.message
-          : "Signup failed. Please try again.";
+          : "회원가입에 실패했습니다. 다시 시도해주세요.";
       setFormState({ status: "error", error: message });
     }
   }
@@ -69,18 +69,17 @@ export default function SignupPage() {
           </svg>
         </div>
         <div>
-          <h2 className="text-base font-semibold text-zinc-900">Check your inbox</h2>
+          <h2 className="text-base font-semibold text-zinc-900">받은 편지함을 확인하세요</h2>
           <p className="mt-2 text-sm text-zinc-500">
-            We&apos;ve sent a verification link to{" "}
-            <span className="font-medium text-zinc-900">{email}</span>. Click it
-            to activate your account.
+            <span className="font-medium text-zinc-900">{email}</span>으로
+            인증 링크를 발송했습니다. 링크를 클릭하여 계정을 활성화하세요.
           </p>
         </div>
         <button
           onClick={() => router.push("/login")}
           className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Back to sign in
+          로그인으로 돌아가기
         </button>
       </div>
     );
@@ -89,8 +88,8 @@ export default function SignupPage() {
   return (
     <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
       <div className="mb-7 text-center">
-        <h2 className="text-lg font-semibold text-zinc-900">Create your account</h2>
-        <p className="mt-1 text-sm text-zinc-500">Get started for free</p>
+        <h2 className="text-lg font-semibold text-zinc-900">계정 만들기</h2>
+        <p className="mt-1 text-sm text-zinc-500">무료로 시작하세요</p>
       </div>
 
       {formState.error && (
@@ -105,7 +104,7 @@ export default function SignupPage() {
             htmlFor="fullName"
             className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
-            Full name
+            이름
           </label>
           <input
             id="fullName"
@@ -115,7 +114,7 @@ export default function SignupPage() {
             value={fullName}
             onChange={(e) => setFullName(e.target.value)}
             className={inputCls}
-            placeholder="Jane Doe"
+            placeholder="홍길동"
           />
         </div>
 
@@ -124,7 +123,7 @@ export default function SignupPage() {
             htmlFor="email"
             className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
-            Email
+            이메일
           </label>
           <input
             id="email"
@@ -143,7 +142,7 @@ export default function SignupPage() {
             htmlFor="password"
             className="mb-1.5 block text-sm font-medium text-zinc-700"
           >
-            Password
+            비밀번호
           </label>
           <input
             id="password"
@@ -154,16 +153,16 @@ export default function SignupPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className={inputCls}
-            placeholder="Min. 8 characters"
+            placeholder="최소 8자 이상"
           />
           {password.length > 0 && password.length < 8 && (
             <p className="mt-1.5 text-xs text-amber-600">
-              Password must be at least 8 characters.
+              비밀번호는 최소 8자 이상이어야 합니다.
             </p>
           )}
           {password.length >= 8 && (
             <p className="mt-1.5 text-xs text-green-600">
-              Password length looks good.
+              비밀번호 길이가 적합합니다.
             </p>
           )}
         </div>
@@ -176,20 +175,20 @@ export default function SignupPage() {
             className="mt-0.5 h-4 w-4 rounded border-zinc-300 accent-zinc-900"
           />
           <span className="text-sm text-zinc-600">
-            I agree to the{" "}
             <a
               href="/terms"
               className="font-medium text-zinc-900 hover:underline"
             >
-              Terms of Service
-            </a>{" "}
-            and{" "}
+              이용약관
+            </a>
+            {" "}및{" "}
             <a
               href="/privacy"
               className="font-medium text-zinc-900 hover:underline"
             >
-              Privacy Policy
+              개인정보처리방침
             </a>
+            에 동의합니다
           </span>
         </label>
 
@@ -201,21 +200,21 @@ export default function SignupPage() {
           {formState.status === "loading" ? (
             <span className="flex items-center justify-center gap-2">
               <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-              Creating account…
+              계정 생성 중…
             </span>
           ) : (
-            "Create account"
+            "계정 만들기"
           )}
         </button>
       </form>
 
       <p className="mt-6 text-center text-sm text-zinc-500">
-        Already have an account?{" "}
+        이미 계정이 있으신가요?{" "}
         <Link
           href="/login"
           className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Sign in
+          로그인
         </Link>
       </p>
     </div>

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -28,7 +28,7 @@ function VerifyEmailContent() {
       })
       .catch((err: unknown) => {
         const message =
-          err instanceof Error ? err.message : "Verification failed.";
+          err instanceof Error ? err.message : "인증에 실패했습니다.";
         setErrorMsg(message);
         setState("error");
       });
@@ -38,7 +38,7 @@ function VerifyEmailContent() {
     return (
       <div className="animate-fade-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
         <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900" />
-        <p className="text-sm text-zinc-500">Verifying your email…</p>
+        <p className="text-sm text-zinc-500">이메일 인증 중…</p>
       </div>
     );
   }
@@ -62,8 +62,8 @@ function VerifyEmailContent() {
           </svg>
         </div>
         <div>
-          <h2 className="text-base font-semibold text-zinc-900">Email verified!</h2>
-          <p className="mt-2 text-sm text-zinc-500">Redirecting you to sign in…</p>
+          <h2 className="text-base font-semibold text-zinc-900">이메일 인증 완료!</h2>
+          <p className="mt-2 text-sm text-zinc-500">로그인 페이지로 이동합니다…</p>
         </div>
       </div>
     );
@@ -72,16 +72,15 @@ function VerifyEmailContent() {
   if (state === "missing") {
     return (
       <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
-        <h2 className="text-base font-semibold text-zinc-900">Missing token</h2>
+        <h2 className="text-base font-semibold text-zinc-900">토큰 없음</h2>
         <p className="text-sm text-zinc-500">
-          The verification link is invalid or expired. Check your inbox for the
-          latest verification email.
+          인증 링크가 유효하지 않거나 만료되었습니다. 받은 편지함에서 최신 인증 이메일을 확인해주세요.
         </p>
         <Link
           href="/login"
           className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
         >
-          Back to sign in
+          로그인으로 돌아가기
         </Link>
       </div>
     );
@@ -105,7 +104,7 @@ function VerifyEmailContent() {
         </svg>
       </div>
       <div>
-        <h2 className="text-base font-semibold text-zinc-900">Verification failed</h2>
+        <h2 className="text-base font-semibold text-zinc-900">인증 실패</h2>
         {errorMsg && (
           <p className="mt-2 text-sm text-red-600">{errorMsg}</p>
         )}
@@ -114,7 +113,7 @@ function VerifyEmailContent() {
         href="/login"
         className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
       >
-        Back to sign in
+        로그인으로 돌아가기
       </Link>
     </div>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,10 +9,10 @@ export default function NotFound() {
 
       <div className="space-y-1.5">
         <h1 className="text-base font-semibold text-zinc-900">
-          Page not found
+          페이지를 찾을 수 없습니다
         </h1>
         <p className="text-sm text-zinc-500">
-          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+          찾으시는 페이지가 존재하지 않거나 이동되었습니다.
         </p>
       </div>
 
@@ -20,7 +20,7 @@ export default function NotFound() {
         href="/contracts"
         className="rounded-lg bg-zinc-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
       >
-        Go to contracts
+        계약서로 이동
       </Link>
     </div>
   );

--- a/src/components/contract/EditContractModal.tsx
+++ b/src/components/contract/EditContractModal.tsx
@@ -34,7 +34,7 @@ export default function EditContractModal({
 
   async function handleSave() {
     if (!form.title?.trim()) {
-      setError("Title cannot be empty.");
+      setError("제목을 입력해주세요.");
       return;
     }
 
@@ -51,7 +51,7 @@ export default function EditContractModal({
       const updated = await api.updateContract(contract.id, payload);
       onSaved(updated);
     } catch (err: unknown) {
-      setError(`Failed to save: ${getErrorMessage(err, "Unknown error")}`);
+      setError(`저장 실패: ${getErrorMessage(err, "알 수 없는 오류")}`);
     } finally {
       setSaving(false);
     }
@@ -62,12 +62,12 @@ export default function EditContractModal({
       <div className="w-full max-w-md animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
         {/* Header */}
         <div className="mb-5 flex items-center justify-between">
-          <h3 className="text-base font-semibold text-zinc-900">Edit contract</h3>
+          <h3 className="text-base font-semibold text-zinc-900">계약서 수정</h3>
           <button
             onClick={saving ? undefined : onClose}
             disabled={saving}
             className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 disabled:opacity-50"
-            aria-label="Close"
+            aria-label="닫기"
           >
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -77,7 +77,7 @@ export default function EditContractModal({
 
         <div className="space-y-4">
           <div>
-            <label className={labelCls}>Title</label>
+            <label className={labelCls}>제목</label>
             <input
               type="text"
               value={form.title ?? ""}
@@ -88,7 +88,7 @@ export default function EditContractModal({
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className={labelCls}>Language</label>
+              <label className={labelCls}>언어</label>
               <input
                 type="text"
                 value={form.language ?? ""}
@@ -98,7 +98,7 @@ export default function EditContractModal({
               />
             </div>
             <div>
-              <label className={labelCls}>Contract type</label>
+              <label className={labelCls}>계약 유형</label>
               <input
                 type="text"
                 value={form.contractType ?? ""}
@@ -110,8 +110,8 @@ export default function EditContractModal({
           </div>
           <div>
             <label className={labelCls}>
-              Tags{" "}
-              <span className="text-xs font-normal text-zinc-400">(JSON array)</span>
+              태그{" "}
+              <span className="text-xs font-normal text-zinc-400">(JSON 배열)</span>
             </label>
             <input
               type="text"
@@ -123,8 +123,8 @@ export default function EditContractModal({
           </div>
           <div>
             <label className={labelCls}>
-              Parties{" "}
-              <span className="text-xs font-normal text-zinc-400">(JSON array)</span>
+              당사자{" "}
+              <span className="text-xs font-normal text-zinc-400">(JSON 배열)</span>
             </label>
             <input
               type="text"
@@ -148,7 +148,7 @@ export default function EditContractModal({
             disabled={saving}
             className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:opacity-50"
           >
-            Cancel
+            취소
           </button>
           <button
             onClick={handleSave}
@@ -158,10 +158,10 @@ export default function EditContractModal({
             {saving ? (
               <span className="flex items-center gap-2">
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-                Saving…
+                저장 중…
               </span>
             ) : (
-              "Save changes"
+              "변경 사항 저장"
             )}
           </button>
         </div>

--- a/src/components/evidence/CitationCard.tsx
+++ b/src/components/evidence/CitationCard.tsx
@@ -12,10 +12,10 @@ interface CitationCardProps {
 
 // Type label without emoji
 const TYPE_LABEL: Record<string, string> = {
-  case: "Case law",
-  policy: "Policy",
-  guideline: "Guideline",
-  clause: "Similar clause",
+  case: "판례",
+  policy: "정책",
+  guideline: "가이드라인",
+  clause: "유사 조항",
 };
 
 // Type icon — SVG only
@@ -74,13 +74,13 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
       const text = targetClause
         ? targetClause.content
         : resp.clauses.map((c) => c.content).join("\n\n");
-      setModal({ open: true, content: text || "(no content)", loading: false, error: null });
+      setModal({ open: true, content: text || "(내용 없음)", loading: false, error: null });
     } catch {
       setModal({
         open: true,
         content: null,
         loading: false,
-        error: "Failed to load source snippet.",
+        error: "소스 스니펫을 불러오지 못했습니다.",
       });
     }
   }
@@ -124,7 +124,7 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
               onClick={() => setExpanded((v) => !v)}
               className="cursor-pointer text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-600"
             >
-              {expanded ? "Show less" : "Show more"}
+              {expanded ? "접기" : "더 보기"}
             </button>
           )}
 
@@ -133,7 +133,7 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
               onClick={handleViewSource}
               className="cursor-pointer text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-600 hover:underline"
             >
-              View source
+              소스 보기
             </button>
           )}
         </div>

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -119,14 +119,14 @@ export default function EvidencePanel({
               <button
                 onClick={() => setShowOverride(true)}
                 className="cursor-pointer rounded-md px-2.5 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
-                title="Override risk level"
+                title="리스크 수준 오버라이드"
               >
-                Override
+                오버라이드
               </button>
               <button
                 onClick={onClose}
                 className="cursor-pointer rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
-                aria-label="Close panel"
+                aria-label="패널 닫기"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -136,7 +136,7 @@ export default function EvidencePanel({
           </div>
           {clauseResult.overriddenRiskLevel && clauseResult.overrideReason && (
             <p className="mt-2 text-xs text-zinc-400 leading-relaxed line-clamp-2">
-              <span className="font-medium text-zinc-500">Override reason: </span>
+              <span className="font-medium text-zinc-500">오버라이드 사유: </span>
               {clauseResult.overrideReason}
             </p>
           )}
@@ -146,7 +146,7 @@ export default function EvidencePanel({
           {/* Summary */}
           {clauseResult.summary && (
             <div className="border-b border-zinc-100 px-4 py-4">
-              <SectionLabel>Summary</SectionLabel>
+              <SectionLabel>요약</SectionLabel>
               <p className="text-sm text-zinc-700 leading-relaxed">
                 {clauseResult.summary}
               </p>
@@ -163,7 +163,7 @@ export default function EvidencePanel({
                       d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                   </svg>
                 </div>
-                <p className="text-sm text-zinc-400">No evidence data available.</p>
+                <p className="text-sm text-zinc-400">증거 데이터가 없습니다.</p>
               </div>
             ) : loadState === "loading" ? (
               <div className="flex justify-center py-10">
@@ -171,13 +171,13 @@ export default function EvidencePanel({
               </div>
             ) : loadState === "error" ? (
               <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
-                Failed to load evidence.
+                증거를 불러오지 못했습니다.
               </div>
             ) : evidenceSet ? (
               <>
                 {/* Rationale */}
                 <div>
-                  <SectionLabel>Rationale</SectionLabel>
+                  <SectionLabel>판단 근거</SectionLabel>
                   <p className="text-sm text-zinc-700 leading-relaxed">
                     {evidenceSet.rationale}
                   </p>
@@ -187,7 +187,7 @@ export default function EvidencePanel({
                 {citations.length > 0 && (
                   <div>
                     <SectionLabel>
-                      Supporting evidence ({citations.length})
+                      지원 증거 ({citations.length})
                     </SectionLabel>
                     <div className="space-y-2">
                       {citations.map((citation) => (
@@ -206,10 +206,10 @@ export default function EvidencePanel({
                       {retrieving ? (
                         <>
                           <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-500" />
-                          Loading more…
+                          더 불러오는 중…
                         </>
                       ) : (
-                        "Load more evidence"
+                        "증거 더 보기"
                       )}
                     </button>
                   </div>
@@ -218,7 +218,7 @@ export default function EvidencePanel({
                 {/* Recommended actions */}
                 {actions.length > 0 && (
                   <div>
-                    <SectionLabel>Recommended actions</SectionLabel>
+                    <SectionLabel>권장 조치</SectionLabel>
                     <ul className="space-y-2">
                       {actions.map((action, i) => (
                         <li key={i} className="flex items-start gap-2.5 text-sm text-zinc-700">

--- a/src/components/risk/OverrideDialog.tsx
+++ b/src/components/risk/OverrideDialog.tsx
@@ -15,6 +15,13 @@ interface OverrideDialogProps {
 
 const RISK_LEVELS: RiskLevel[] = ["HIGH", "MEDIUM", "LOW"];
 
+const LEVEL_LABELS: Record<RiskLevel, string> = {
+  HIGH:   "높음",
+  MEDIUM: "중간",
+  LOW:    "낮음",
+  none:   "—",
+};
+
 const LEVEL_STYLES: Record<RiskLevel, string> = {
   HIGH: "border-red-200 text-red-700 data-[selected]:border-red-600 data-[selected]:bg-red-600 data-[selected]:text-white",
   MEDIUM: "border-amber-200 text-amber-700 data-[selected]:border-amber-500 data-[selected]:bg-amber-500 data-[selected]:text-white",
@@ -39,11 +46,11 @@ export default function OverrideDialog({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!reason.trim()) {
-      setError("Please provide a reason for the override.");
+      setError("오버라이드 사유를 입력해주세요.");
       return;
     }
     if (newLevel === currentLevel) {
-      setError("Please select a different risk level.");
+      setError("다른 리스크 수준을 선택해주세요.");
       return;
     }
 
@@ -68,7 +75,7 @@ export default function OverrideDialog({
 
       onApplied(updated);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to save override.");
+      setError(err instanceof Error ? err.message : "오버라이드 저장에 실패했습니다.");
     } finally {
       setSubmitting(false);
     }
@@ -79,11 +86,11 @@ export default function OverrideDialog({
       <div className="w-full max-w-md animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
         {/* Header */}
         <div className="mb-5 flex items-center justify-between">
-          <h3 className="text-base font-semibold text-zinc-900">Override risk level</h3>
+          <h3 className="text-base font-semibold text-zinc-900">리스크 수준 오버라이드</h3>
           <button
             onClick={onClose}
             className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
-            aria-label="Close"
+            aria-label="닫기"
           >
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -92,14 +99,14 @@ export default function OverrideDialog({
         </div>
 
         <p className="mb-5 flex items-center gap-2 text-sm text-zinc-500">
-          Current assessment:
+          현재 평가:
           <RiskBadge level={currentLevel} />
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="mb-2.5 block text-sm font-medium text-zinc-700">
-              New risk level
+              새 리스크 수준
             </label>
             <div className="flex gap-2">
               {RISK_LEVELS.map((level) => (
@@ -119,7 +126,7 @@ export default function OverrideDialog({
                       : LEVEL_STYLES[level],
                   ].join(" ")}
                 >
-                  {level}
+                  {LEVEL_LABELS[level]}
                 </button>
               ))}
             </div>
@@ -130,7 +137,7 @@ export default function OverrideDialog({
               htmlFor="override-reason"
               className="mb-1.5 block text-sm font-medium text-zinc-700"
             >
-              Reason <span className="text-red-500">*</span>
+              사유 <span className="text-red-500">*</span>
             </label>
             <textarea
               id="override-reason"
@@ -138,7 +145,7 @@ export default function OverrideDialog({
               rows={3}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
-              placeholder="Explain why the AI assessment should be overridden…"
+              placeholder="AI 평가를 오버라이드해야 하는 이유를 설명해주세요…"
               className="w-full resize-none rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
             />
           </div>
@@ -155,7 +162,7 @@ export default function OverrideDialog({
               onClick={onClose}
               className="flex-1 rounded-lg border border-zinc-200 px-4 py-2.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50"
             >
-              Cancel
+              취소
             </button>
             <button
               type="submit"
@@ -165,10 +172,10 @@ export default function OverrideDialog({
               {submitting ? (
                 <span className="flex items-center justify-center gap-2">
                   <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-                  Saving…
+                  저장 중…
                 </span>
               ) : (
-                "Save override"
+                "오버라이드 저장"
               )}
             </button>
           </div>

--- a/src/components/risk/RiskBadge.tsx
+++ b/src/components/risk/RiskBadge.tsx
@@ -14,9 +14,9 @@ const STYLES: Record<RiskLevel, string> = {
 };
 
 const LABELS: Record<RiskLevel, string> = {
-  HIGH:   "High",
-  MEDIUM: "Medium",
-  LOW:    "Low",
+  HIGH:   "높음",
+  MEDIUM: "중간",
+  LOW:    "낮음",
   none:   "—",
 };
 
@@ -42,7 +42,7 @@ export default function RiskBadge({
       {LABELS[level] ?? level}
       {overridden && (
         <span className="rounded px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide opacity-60 bg-current/10">
-          edited
+          수정됨
         </span>
       )}
     </span>

--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -39,18 +39,18 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
       onCreated({ id: org.id, name: org.name, plan: org.plan, role: "admin" });
     } catch (err: unknown) {
       setStatus("error");
-      setErrorMsg(err instanceof Error ? err.message : "Failed to create organization");
+      setErrorMsg(err instanceof Error ? err.message : "조직 생성에 실패했습니다.");
     }
   }
 
   return (
     <Modal onClose={onClose}>
       <div className="w-full max-w-sm animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
-        <h2 className="mb-5 text-base font-semibold text-zinc-900">New Organization</h2>
+        <h2 className="mb-5 text-base font-semibold text-zinc-900">새 조직</h2>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
             <label htmlFor="org-name" className="text-sm font-medium text-zinc-700">
-              Organization name
+              조직 이름
             </label>
             <input
               id="org-name"
@@ -74,7 +74,7 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
               onClick={onClose}
               className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-50"
             >
-              Cancel
+              취소
             </button>
             <button
               type="submit"
@@ -84,10 +84,10 @@ function NewOrgModal({ onClose, onCreated }: NewOrgModalProps) {
               {status === "loading" ? (
                 <span className="flex items-center gap-2">
                   <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
-                  Creating…
+                  생성 중…
                 </span>
               ) : (
-                "Create"
+                "만들기"
               )}
             </button>
           </div>
@@ -150,7 +150,7 @@ export function OrgSwitcher() {
     switchOrganization(org.id, org.name);
     setShowModal(false);
     setOpen(false);
-    toast("success", "Organization created");
+    toast("success", "조직이 생성되었습니다.");
   }
 
   const currentOrgName = user?.organizationName;
@@ -195,14 +195,14 @@ export function OrgSwitcher() {
             {loadStatus === "loading" && (
               <div className="flex items-center gap-2 px-3 py-2.5">
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />
-                <span className="text-xs text-zinc-400">Loading…</span>
+                <span className="text-xs text-zinc-400">로딩 중…</span>
               </div>
             )}
             {loadStatus === "error" && (
-              <p className="px-3 py-2.5 text-xs text-red-500">Failed to load organizations</p>
+              <p className="px-3 py-2.5 text-xs text-red-500">조직 목록을 불러오지 못했습니다.</p>
             )}
             {loadStatus === "idle" && orgs.length === 0 && (
-              <p className="px-3 py-2.5 text-xs text-zinc-400">No organizations found</p>
+              <p className="px-3 py-2.5 text-xs text-zinc-400">조직을 찾을 수 없습니다.</p>
             )}
             {loadStatus === "idle" &&
               orgs.map((org) => {
@@ -246,7 +246,7 @@ export function OrgSwitcher() {
                     d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
-                Organization settings
+                조직 설정
               </Link>
               <button
                 onClick={() => {
@@ -258,7 +258,7 @@ export function OrgSwitcher() {
                 <svg className="h-4 w-4 flex-shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
-                New organization
+                새 조직
               </button>
             </div>
           </div>

--- a/src/components/upload/DropZone.tsx
+++ b/src/components/upload/DropZone.tsx
@@ -14,11 +14,11 @@ export default function DropZone({ onFile, disabled = false }: DropZoneProps) {
   function validateAndEmit(file: File) {
     setError(null);
     if (file.type !== "application/pdf" && !file.name.toLowerCase().endsWith(".pdf")) {
-      setError("Only PDF files are supported.");
+      setError("PDF 파일만 지원됩니다.");
       return;
     }
     if (file.size > 50 * 1024 * 1024) {
-      setError("File must be smaller than 50 MB.");
+      setError("파일 크기는 50 MB 미만이어야 합니다.");
       return;
     }
     onFile(file);
@@ -88,15 +88,15 @@ export default function DropZone({ onFile, disabled = false }: DropZoneProps) {
           </svg>
         </div>
         <p className="text-sm font-medium text-zinc-700">
-          Drag &amp; drop your PDF here
+          PDF 파일을 여기에 끌어다 놓으세요
         </p>
         <p className="mt-1 text-xs text-zinc-400">
-          or{" "}
+          또는{" "}
           <span className="font-medium text-zinc-600 underline underline-offset-2">
-            browse to upload
+            파일 선택하여 업로드
           </span>
         </p>
-        <p className="mt-2 text-xs text-zinc-300">PDF only — max 50 MB</p>
+        <p className="mt-2 text-xs text-zinc-300">PDF 전용 — 최대 50 MB</p>
         <input
           id="contract-file-input"
           type="file"

--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -11,12 +11,12 @@ interface IngestionProgressProps {
 }
 
 const STEP_LABELS: Record<string, string> = {
-  pending:   "Queued",
-  parsing:   "Parsing document…",
-  chunking:  "Splitting into clauses…",
-  indexing:  "Building search index…",
-  completed: "Complete",
-  failed:    "Failed",
+  pending:   "대기 중",
+  parsing:   "문서 파싱 중…",
+  chunking:  "조항 분리 중…",
+  indexing:  "검색 인덱스 구축 중…",
+  completed: "완료",
+  failed:    "실패",
 };
 
 export default function IngestionProgress({
@@ -74,7 +74,7 @@ export default function IngestionProgress({
     return (
       <div className="flex items-center gap-2 text-xs text-zinc-500">
         <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />
-        <span>Processing…</span>
+        <span>처리 중…</span>
       </div>
     );
   }

--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -26,17 +26,17 @@ const RISK_INDICATOR: Record<RiskLevel, string> = {
 const FILTER_LEVELS: Array<{ level: RiskLevel; label: string; activeClass: string }> = [
   {
     level: "HIGH",
-    label: "HIGH",
+    label: "높음",
     activeClass: "bg-red-100 text-red-700 ring-red-300",
   },
   {
     level: "MEDIUM",
-    label: "MED",
+    label: "중간",
     activeClass: "bg-amber-100 text-amber-700 ring-amber-300",
   },
   {
     level: "LOW",
-    label: "LOW",
+    label: "낮음",
     activeClass: "bg-green-100 text-green-700 ring-green-300",
   },
 ];
@@ -95,7 +95,7 @@ export default function ClauseNav({
       <div className="border-b border-zinc-100 px-4 py-3.5">
         <div className="flex items-center justify-between">
           <p className="text-xs font-semibold text-zinc-900">
-            Clauses
+            조항
             <span className="ml-1.5 font-normal text-zinc-400">
               ({activeFilters.size > 0 ? `${visibleClauses.length}/` : ""}
               {clauses.length})
@@ -106,12 +106,12 @@ export default function ClauseNav({
               onClick={clearFilters}
               className="cursor-pointer text-xs text-zinc-400 hover:text-zinc-600 transition-colors"
             >
-              Clear
+              초기화
             </button>
           )}
         </div>
         {hasAnalysis && (
-          <p className="mt-0.5 text-xs text-zinc-400">{analyzedCount} analyzed</p>
+          <p className="mt-0.5 text-xs text-zinc-400">{analyzedCount}개 분석됨</p>
         )}
 
         {/* Risk filter toggles — shown only when analysis results are available */}
@@ -130,7 +130,7 @@ export default function ClauseNav({
                 <button
                   key={level}
                   onClick={() => toggleFilter(level)}
-                  title={`Filter by ${level} risk (${count} clauses)`}
+                  title={`${label} 리스크 필터 (${count}개 조항)`}
                   className={[
                     "cursor-pointer inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ring-1 transition-colors",
                     isActive
@@ -166,7 +166,7 @@ export default function ClauseNav({
             </svg>
           </div>
           <p className="text-xs text-zinc-400 leading-relaxed">
-            No clauses extracted yet.
+            아직 추출된 조항이 없습니다.
           </p>
         </div>
       )}
@@ -181,13 +181,13 @@ export default function ClauseNav({
             </svg>
           </div>
           <p className="text-xs text-zinc-400 leading-relaxed">
-            No clauses match the selected filter.
+            선택한 필터에 맞는 조항이 없습니다.
           </p>
           <button
             onClick={clearFilters}
             className="cursor-pointer text-xs text-zinc-500 underline underline-offset-2 hover:text-zinc-700"
           >
-            Clear filter
+            필터 초기화
           </button>
         </div>
       )}

--- a/src/components/viewer/DocumentViewer.tsx
+++ b/src/components/viewer/DocumentViewer.tsx
@@ -66,7 +66,7 @@ export default function DocumentViewer({
   if (error) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-red-600">
-        Failed to load document: {error}
+        문서를 불러오지 못했습니다: {error}
       </div>
     );
   }


### PR DESCRIPTION
## 변경사항

- 인증 페이지 (로그인, 회원가입, 비밀번호 재설정, 이메일 인증, 비밀번호 찾기) 모든 텍스트 한국어 변환
- 앱 페이지 (대시보드, 계약서 목록, 계약서 상세, 설정, 조직 설정, 감사 로그, 404, 에러) 한국어 변환
- 공통 컴포넌트 한국어 변환:
  - ClauseNav, DocumentViewer (뷰어)
  - EvidencePanel, CitationCard (증거 패널)
  - RiskBadge, OverrideDialog (리스크)
  - DropZone, IngestionProgress (업로드)
  - OrgSwitcher, EditContractModal (UI)
- 날짜/시간 포맷을 `ko-KR` 로케일로 통일
- 버튼 텍스트: Submit→제출, Cancel→취소, Upload→업로드, Sign In→로그인, Sign Up→회원가입

## QA 결과

- 변수명, 코드 로직, API 파라미터 변경 없음 (UI 텍스트만 변환)
- `any` 타입 미사용, `console.log` 미사용
- 타입 정의 변경 없음

Closes #116