### PR TITLE
feat(#118): EvidencePanel 및 ClauseNav에 confidence score 표시

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -43,6 +43,81 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+// ─── Confidence gauge ───────────────────────────────────────────────────────
+
+interface ConfidenceGaugeProps {
+  /** 0.0 ~ 1.0 */
+  value: number;
+}
+
+function confidenceLabel(v: number): string {
+  if (v >= 0.7) return "높음";
+  if (v >= 0.4) return "보통";
+  return "낮음";
+}
+
+function confidenceColors(v: number): {
+  bar: string;
+  text: string;
+  bg: string;
+  ring: string;
+} {
+  if (v >= 0.7)
+    return {
+      bar: "bg-green-500",
+      text: "text-green-700",
+      bg: "bg-green-50",
+      ring: "ring-green-200",
+    };
+  if (v >= 0.4)
+    return {
+      bar: "bg-amber-400",
+      text: "text-amber-700",
+      bg: "bg-amber-50",
+      ring: "ring-amber-200",
+    };
+  return {
+    bar: "bg-red-500",
+    text: "text-red-700",
+    bg: "bg-red-50",
+    ring: "ring-red-200",
+  };
+}
+
+function ConfidenceGauge({ value }: ConfidenceGaugeProps) {
+  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100);
+  const label = confidenceLabel(value);
+  const { bar, text, bg, ring } = confidenceColors(value);
+
+  return (
+    <div className="mt-2.5 flex items-center gap-2.5">
+      {/* Bar */}
+      <div
+        className="h-1.5 flex-1 overflow-hidden rounded-full bg-zinc-100"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`AI 신뢰도 ${pct}%`}
+      >
+        <div
+          className={`h-full rounded-full transition-all ${bar}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      {/* Badge */}
+      <span
+        className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ring-1 whitespace-nowrap ${bg} ${text} ${ring}`}
+      >
+        {label}&nbsp;{pct}%
+      </span>
+    </div>
+  );
+}
+
+// ─── Main component ─────────────────────────────────────────────────────────
+
 export default function EvidencePanel({
   clauseResult,
   analysisId,
@@ -60,6 +135,10 @@ export default function EvidencePanel({
     clauseResult.riskLevel;
 
   const evidenceSetId = clauseResult.evidenceSetId;
+
+  // confidence is 0~1; default 0.5 if missing
+  const confidence: number =
+    typeof clauseResult.confidence === "number" ? clauseResult.confidence : 0.5;
 
   useEffect(() => {
     if (!evidenceSetId) return;
@@ -134,6 +213,15 @@ export default function EvidencePanel({
               </button>
             </div>
           </div>
+
+          {/* Confidence gauge — always shown when analysis result present */}
+          <div>
+            <p className="mt-2 text-[10px] font-semibold uppercase tracking-widest text-zinc-400">
+              AI 신뢰도
+            </p>
+            <ConfidenceGauge value={confidence} />
+          </div>
+
           {clauseResult.overriddenRiskLevel && clauseResult.overrideReason && (
             <p className="mt-2 text-xs text-zinc-400 leading-relaxed line-clamp-2">
               <span className="font-medium text-zinc-500">오버라이드 사유: </span>

--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -41,6 +41,31 @@ const FILTER_LEVELS: Array<{ level: RiskLevel; label: string; activeClass: strin
   },
 ];
 
+/** Threshold below which the confidence is considered low and a warning is shown. */
+const LOW_CONFIDENCE_THRESHOLD = 0.4;
+
+/**
+ * Small warning icon shown next to clauses with low AI confidence (< 0.4).
+ * Helps reviewers prioritise manual checks.
+ */
+function LowConfidenceIcon({ isSelected }: { isSelected: boolean }) {
+  return (
+    <svg
+      className={`h-3 w-3 flex-shrink-0 ${isSelected ? "text-amber-300" : "text-amber-500"}`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-label="낮은 신뢰도"
+      role="img"
+    >
+      <path
+        fillRule="evenodd"
+        d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export default function ClauseNav({
   clauses,
   clauseResults,
@@ -204,6 +229,16 @@ export default function ClauseNav({
             const isSelected = clause.id === selectedClauseId;
             const hasResult = !!result;
 
+            // Show low-confidence warning when confidence is available and below threshold.
+            // Only applies to analyzed clauses; suppress when overridden (human judgement takes over).
+            const confidence =
+              typeof result?.confidence === "number" ? result.confidence : null;
+            const isLowConfidence =
+              hasResult &&
+              !result?.overriddenRiskLevel &&
+              confidence !== null &&
+              confidence < LOW_CONFIDENCE_THRESHOLD;
+
             return (
               <li key={clause.id}>
                 <button
@@ -230,13 +265,21 @@ export default function ClauseNav({
                         <span className="flex-1 leading-snug line-clamp-2 text-xs font-medium">
                           {clause.label ?? `Clause ${clause.clauseIndex + 1}`}
                         </span>
-                        {result && (
-                          <RiskBadge
-                            level={riskLevel}
-                            overridden={!!result.overriddenRiskLevel}
-                            className={isSelected ? "opacity-90 flex-shrink-0" : "flex-shrink-0"}
-                          />
-                        )}
+                        <div className="flex flex-shrink-0 items-center gap-1">
+                          {/* Low confidence warning icon */}
+                          {isLowConfidence && (
+                            <span title={`AI 신뢰도 낮음 (${Math.round((confidence ?? 0) * 100)}%) — 수동 검토 권장`}>
+                              <LowConfidenceIcon isSelected={isSelected} />
+                            </span>
+                          )}
+                          {result && (
+                            <RiskBadge
+                              level={riskLevel}
+                              overridden={!!result.overriddenRiskLevel}
+                              className={isSelected ? "opacity-90" : ""}
+                            />
+                          )}
+                        </div>
                       </div>
                       {clause.pageStart > 0 && (
                         <span


### PR DESCRIPTION
## 변경사항

- **EvidencePanel**: 헤더에 AI 신뢰도 게이지 바 + 레이블/퍼센트 뱃지 추가
  - 높음(≥70%): 녹색 / 보통(40~70%): 황색 / 낮음(<40%): 적색
  - confidence 미설정 시 API 기본값과 동일한 0.5로 fallback
- **ClauseNav**: 낮은 신뢰도(<40%) 조항에 경고 삼각형 아이콘 표시
  - 오버라이드 완료 조항은 경고 숨김 (인간 판단이 우선)
  - tooltip에 정확한 % 및 "수동 검토 권장" 문구 표시

## QA 결과

- [x] TypeScript 타입 오류 없음 (`tsc --noEmit`)
- [x] ESLint 경고/오류 없음
- [x] 기존 리스크 필터 동작 유지
- [x] confidence 없는 결과(null/undefined)에서 오류 없음
- [x] 오버라이드 완료 조항 경고 아이콘 올바르게 숨김

Closes #118