### PR TITLE
feat(#120): 계약 목록 필터 URL 쿼리 파라미터 반영

### DIFF
--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, Suspense } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { useDebounce } from "@/lib/useDebounce";
@@ -61,9 +62,11 @@ function DocIcon() {
   );
 }
 
-export default function ContractsPage() {
+function ContractsPageInner() {
   const user = useAuthStore((s) => s.user);
   const { toast } = useToast();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const orgId = user?.organizationId ?? "";
 
   const [contracts, setContracts] = useState<Contract[]>([]);
@@ -89,9 +92,11 @@ export default function ContractsPage() {
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const [bulkDeleteProgress, setBulkDeleteProgress] = useState({ done: 0, total: 0 });
 
-  // Search & filter state (raw — user input)
-  const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<ContractStatus | "">("");
+  // Search & filter state — initialised from URL search params
+  const [searchQuery, setSearchQuery] = useState<string>(() => searchParams.get("q") ?? "");
+  const [statusFilter, setStatusFilter] = useState<ContractStatus | "">(
+    () => (searchParams.get("status") as ContractStatus | null) ?? ""
+  );
 
   // Debounced search query — actual API call uses this
   const debouncedQuery = useDebounce(searchQuery, 300);
@@ -101,6 +106,18 @@ export default function ContractsPage() {
 
   // Ref to track the current fetch to avoid stale closures race conditions
   const fetchIdRef = useRef(0);
+
+  // Keep URL in sync whenever filter state changes.
+  // We use router.replace so the filter navigation doesn't pollute the history stack.
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (searchQuery.trim()) params.set("q", searchQuery.trim());
+    if (statusFilter) params.set("status", statusFilter);
+
+    const queryString = params.toString();
+    const newPath = queryString ? `/contracts?${queryString}` : "/contracts";
+    router.replace(newPath);
+  }, [searchQuery, statusFilter, router]);
 
   const fetchContracts = useCallback(
     async (opts?: { silent?: boolean }) => {
@@ -780,5 +797,17 @@ export default function ContractsPage() {
         </Modal>
       )}
     </div>
+  );
+}
+
+export default function ContractsPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-24">
+        <LoadingSpinner size="md" />
+      </div>
+    }>
+      <ContractsPageInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## 변경사항

- `useSearchParams` / `useRouter`를 활용해 검색어(`?q=`)와 상태 필터(`?status=`)를 URL 파라미터에 반영
- 페이지 초기 로드 시 URL 파라미터에서 필터 초기값을 읽어 적용
- 필터 변경 시 `router.replace()`로 URL 업데이트 (브라우저 히스토리 오염 방지)
- 필터 초기화 버튼 클릭 시 URL 파라미터도 제거됨
- `useSearchParams` 사용 요구사항에 따라 컴포넌트를 `Suspense`로 감쌈

## QA 결과

- [x] `npm run build` 성공 (TypeScript 오류 없음)
- [x] `/contracts?status=ready` 접속 시 "분석 완료" 필터가 선택된 상태로 로드됨
- [x] `/contracts?q=NDA` 접속 시 검색어 "NDA"가 입력된 상태로 로드됨
- [x] 필터 변경 시 URL이 즉시 업데이트됨
- [x] 초기화 버튼 클릭 시 URL에서 파라미터가 제거됨

Closes #120