### PR TITLE
fix(#122): 폴링 루프 silent catch → 연속 실패 시 에러 상태 표시

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -172,11 +172,14 @@ export default function ContractViewerPage({
 
     let timerId: ReturnType<typeof setInterval> | null = null;
     let stopped = false;
+    let failCount = 0;
+    const MAX_FAILS = 5;
 
     async function pollContract() {
       try {
         const updated = await api.getContract(contractId);
         if (stopped) return;
+        failCount = 0;
         setContract(updated);
 
         if (!PROCESSING_STATUSES.has(updated.status)) {
@@ -196,7 +199,12 @@ export default function ContractViewerPage({
           }
         }
       } catch {
-        // retry silently
+        if (stopped) return;
+        failCount += 1;
+        if (failCount >= MAX_FAILS) {
+          if (timerId) clearInterval(timerId);
+          toast("error", "서버 연결이 끊겼습니다. 페이지를 새로고침해 주세요.");
+        }
       }
     }
 
@@ -213,16 +221,24 @@ export default function ContractViewerPage({
     if (analysisState.phase !== "polling") return;
     const { analysisId } = analysisState;
     let timerId: ReturnType<typeof setInterval> | null = null;
+    let failCount = 0;
+    const MAX_FAILS = 5;
 
     async function poll() {
       try {
         const resp = await api.getAnalysis(analysisId);
+        failCount = 0;
         applyAnalysisResponse(resp, true);
         if (resp.analysis.status === "completed" || resp.analysis.status === "failed") {
           if (timerId) clearInterval(timerId);
         }
       } catch {
-        // retry silently
+        failCount += 1;
+        if (failCount >= MAX_FAILS) {
+          if (timerId) clearInterval(timerId);
+          setAnalysisState({ phase: "idle" });
+          toast("error", "분석 상태를 확인할 수 없습니다. 페이지를 새로고침해 주세요.");
+        }
       }
     }
 

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -128,6 +128,7 @@ export default function EvidencePanel({
   const [evidenceSet, setEvidenceSet] = useState<EvidenceSet | null>(null);
   const [loadState, setLoadState] = useState<EvidenceLoadState>("idle");
   const [retrieving, setRetrieving] = useState(false);
+  const [retrieveError, setRetrieveError] = useState(false);
   const [showOverride, setShowOverride] = useState(false);
 
   const effectiveLevel: RiskLevel =
@@ -155,12 +156,13 @@ export default function EvidencePanel({
   async function handleRetrieveMore() {
     if (!evidenceSetId) return;
     setRetrieving(true);
+    setRetrieveError(false);
     try {
       await api.retrieveEvidence(evidenceSetId, 10);
       const updated = await api.getEvidenceSet(evidenceSetId);
       setEvidenceSet(updated);
     } catch {
-      // silently ignore
+      setRetrieveError(true);
     } finally {
       setRetrieving(false);
     }
@@ -286,20 +288,25 @@ export default function EvidencePanel({
                         />
                       ))}
                     </div>
-                    <button
-                      onClick={handleRetrieveMore}
-                      disabled={retrieving}
-                      className="mt-3 flex items-center gap-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50"
-                    >
-                      {retrieving ? (
-                        <>
-                          <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-500" />
-                          더 불러오는 중…
-                        </>
-                      ) : (
-                        "증거 더 보기"
+                    <div className="mt-3 space-y-1">
+                      <button
+                        onClick={handleRetrieveMore}
+                        disabled={retrieving}
+                        className="flex items-center gap-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50"
+                      >
+                        {retrieving ? (
+                          <>
+                            <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-500" />
+                            더 불러오는 중…
+                          </>
+                        ) : (
+                          "증거 더 보기"
+                        )}
+                      </button>
+                      {retrieveError && (
+                        <p className="text-xs text-red-500">증거를 불러오지 못했습니다. 다시 시도해 주세요.</p>
                       )}
-                    </button>
+                    </div>
                   </div>
                 )}
 

--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -25,6 +25,7 @@ export default function IngestionProgress({
   onError,
 }: IngestionProgressProps) {
   const [job, setJob] = useState<IngestionJob | null>(null);
+  const [networkError, setNetworkError] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onCompleteRef = useRef(onComplete);
   const onErrorRef = useRef(onError);
@@ -36,11 +37,14 @@ export default function IngestionProgress({
 
   useEffect(() => {
     let stopped = false;
+    let failCount = 0;
+    const MAX_FAILS = 5;
 
     async function poll() {
       try {
         const j = await api.getIngestionJob(jobId);
         if (stopped) return;
+        failCount = 0;
         setJob(j);
         if (j.status === "completed" || j.status === "failed") {
           if (timerRef.current) {
@@ -54,7 +58,20 @@ export default function IngestionProgress({
           }
         }
       } catch {
-        // silently retry
+        if (stopped) return;
+        failCount += 1;
+        if (failCount >= MAX_FAILS) {
+          if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+          }
+          setJob((prev) =>
+            prev
+              ? { ...prev, status: "failed", errorMessage: "서버와 연결할 수 없습니다. 페이지를 새로고침해 주세요." }
+              : prev
+          );
+          setNetworkError(true);
+        }
       }
     }
 
@@ -71,6 +88,11 @@ export default function IngestionProgress({
   }, [jobId]);
 
   if (!job) {
+    if (networkError) {
+      return (
+        <p className="text-xs text-red-600">서버와 연결할 수 없습니다. 페이지를 새로고침해 주세요.</p>
+      );
+    }
     return (
       <div className="flex items-center gap-2 text-xs text-zinc-500">
         <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />


### PR DESCRIPTION
## 변경사항
- `IngestionProgress.tsx`: 연속 5회 API 실패 시 폴링 중단 + 에러 메시지 렌더링
- `contracts/[id]/page.tsx` 계약서 상태 폴링: 연속 5회 실패 시 toast 에러 + 폴링 중단
- `contracts/[id]/page.tsx` 분석 폴링: 연속 5회 실패 시 toast 에러 + analysisState를 idle로 복구
- `EvidencePanel.tsx` 증거 더 보기: 실패 시 버튼 아래 인라인 에러 메시지 표시

## QA 결과
- TypeScript 타입 체크 통과 (exit 0)
- 기존 동작 유지: 일시적 네트워크 오류(1-4회)는 자동 재시도, 5회 이상 연속 실패 시에만 사용자 에러 표시

Closes #122