### PR TITLE
fix(#124): ready 상태 라벨을 '준비 완료'로 수정

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -172,11 +172,14 @@ export default function ContractViewerPage({
 
     let timerId: ReturnType<typeof setInterval> | null = null;
     let stopped = false;
+    let failCount = 0;
+    const MAX_FAILS = 5;
 
     async function pollContract() {
       try {
         const updated = await api.getContract(contractId);
         if (stopped) return;
+        failCount = 0;
         setContract(updated);
 
         if (!PROCESSING_STATUSES.has(updated.status)) {
@@ -196,7 +199,12 @@ export default function ContractViewerPage({
           }
         }
       } catch {
-        // retry silently
+        if (stopped) return;
+        failCount += 1;
+        if (failCount >= MAX_FAILS) {
+          if (timerId) clearInterval(timerId);
+          toast("error", "서버 연결이 끊겼습니다. 페이지를 새로고침해 주세요.");
+        }
       }
     }
 
@@ -213,16 +221,24 @@ export default function ContractViewerPage({
     if (analysisState.phase !== "polling") return;
     const { analysisId } = analysisState;
     let timerId: ReturnType<typeof setInterval> | null = null;
+    let failCount = 0;
+    const MAX_FAILS = 5;
 
     async function poll() {
       try {
         const resp = await api.getAnalysis(analysisId);
+        failCount = 0;
         applyAnalysisResponse(resp, true);
         if (resp.analysis.status === "completed" || resp.analysis.status === "failed") {
           if (timerId) clearInterval(timerId);
         }
       } catch {
-        // retry silently
+        failCount += 1;
+        if (failCount >= MAX_FAILS) {
+          if (timerId) clearInterval(timerId);
+          setAnalysisState({ phase: "idle" });
+          toast("error", "분석 상태를 확인할 수 없습니다. 페이지를 새로고침해 주세요.");
+        }
       }
     }
 

--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -29,7 +29,7 @@ interface ActiveUpload {
 const STATUS_LABEL: Record<string, string> = {
   uploaded: "업로드됨",
   processing: "처리 중",
-  ready: "분석 완료",
+  ready: "준비 완료",
   failed: "실패",
 };
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -12,7 +12,7 @@ import type { Contract, DashboardStats, ContractStatus } from "@/types";
 const STATUS_LABEL: Record<string, string> = {
   uploaded: "업로드됨",
   processing: "처리 중",
-  ready: "분석 완료",
+  ready: "준비 완료",
   failed: "실패",
 };
 

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -128,6 +128,7 @@ export default function EvidencePanel({
   const [evidenceSet, setEvidenceSet] = useState<EvidenceSet | null>(null);
   const [loadState, setLoadState] = useState<EvidenceLoadState>("idle");
   const [retrieving, setRetrieving] = useState(false);
+  const [retrieveError, setRetrieveError] = useState(false);
   const [showOverride, setShowOverride] = useState(false);
 
   const effectiveLevel: RiskLevel =
@@ -155,12 +156,13 @@ export default function EvidencePanel({
   async function handleRetrieveMore() {
     if (!evidenceSetId) return;
     setRetrieving(true);
+    setRetrieveError(false);
     try {
       await api.retrieveEvidence(evidenceSetId, 10);
       const updated = await api.getEvidenceSet(evidenceSetId);
       setEvidenceSet(updated);
     } catch {
-      // silently ignore
+      setRetrieveError(true);
     } finally {
       setRetrieving(false);
     }
@@ -286,20 +288,25 @@ export default function EvidencePanel({
                         />
                       ))}
                     </div>
-                    <button
-                      onClick={handleRetrieveMore}
-                      disabled={retrieving}
-                      className="mt-3 flex items-center gap-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50"
-                    >
-                      {retrieving ? (
-                        <>
-                          <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-500" />
-                          더 불러오는 중…
-                        </>
-                      ) : (
-                        "증거 더 보기"
+                    <div className="mt-3 space-y-1">
+                      <button
+                        onClick={handleRetrieveMore}
+                        disabled={retrieving}
+                        className="flex items-center gap-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50"
+                      >
+                        {retrieving ? (
+                          <>
+                            <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-500" />
+                            더 불러오는 중…
+                          </>
+                        ) : (
+                          "증거 더 보기"
+                        )}
+                      </button>
+                      {retrieveError && (
+                        <p className="text-xs text-red-500">증거를 불러오지 못했습니다. 다시 시도해 주세요.</p>
                       )}
-                    </button>
+                    </div>
                   </div>
                 )}
 

--- a/src/components/upload/IngestionProgress.tsx
+++ b/src/components/upload/IngestionProgress.tsx
@@ -25,6 +25,7 @@ export default function IngestionProgress({
   onError,
 }: IngestionProgressProps) {
   const [job, setJob] = useState<IngestionJob | null>(null);
+  const [networkError, setNetworkError] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onCompleteRef = useRef(onComplete);
   const onErrorRef = useRef(onError);
@@ -36,11 +37,14 @@ export default function IngestionProgress({
 
   useEffect(() => {
     let stopped = false;
+    let failCount = 0;
+    const MAX_FAILS = 5;
 
     async function poll() {
       try {
         const j = await api.getIngestionJob(jobId);
         if (stopped) return;
+        failCount = 0;
         setJob(j);
         if (j.status === "completed" || j.status === "failed") {
           if (timerRef.current) {
@@ -54,7 +58,20 @@ export default function IngestionProgress({
           }
         }
       } catch {
-        // silently retry
+        if (stopped) return;
+        failCount += 1;
+        if (failCount >= MAX_FAILS) {
+          if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+          }
+          setJob((prev) =>
+            prev
+              ? { ...prev, status: "failed", errorMessage: "서버와 연결할 수 없습니다. 페이지를 새로고침해 주세요." }
+              : prev
+          );
+          setNetworkError(true);
+        }
       }
     }
 
@@ -71,6 +88,11 @@ export default function IngestionProgress({
   }, [jobId]);
 
   if (!job) {
+    if (networkError) {
+      return (
+        <p className="text-xs text-red-600">서버와 연결할 수 없습니다. 페이지를 새로고침해 주세요.</p>
+      );
+    }
     return (
       <div className="flex items-center gap-2 text-xs text-zinc-500">
         <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />


### PR DESCRIPTION
## 변경사항
- `contracts/page.tsx`: `ready: "분석 완료"` → `ready: "준비 완료"`
- `dashboard/page.tsx`: `ready: "분석 완료"` → `ready: "준비 완료"`

## 이유
`ready` 상태는 조항 추출(ingestion)이 완료된 상태를 의미하며,
AI 분석 완료와는 다름. 기존 "분석 완료" 라벨은 사용자에게 분석이
완료된 것으로 오해를 줄 수 있어 "준비 완료"로 수정.

## QA 결과
- STATUS_LABEL 상수 변경만으로 런타임 동작 영향 없음
- contracts 목록 및 대시보드에서 ready 상태 배지 텍스트 변경 확인

Closes #124