### PR TITLE
feat(#128): 분석 완료 후 문서 요약 카드 표시 및 Citation 타입 확장

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -123,7 +123,7 @@
 | 서버 상태 (설치됨, 미사용) | @tanstack/react-query ^5 |
 | UI 스타일 | Tailwind CSS v4 |
 
-*최종 업데이트: 2026-03-27*
+*최종 업데이트: 2026-04-15*
 
 ---
 
@@ -144,6 +144,28 @@
 - ClauseNav 외부 인터페이스(props)는 변경 없음
 
 **영향**: 없음 (ContractViewerPage 변경 불필요)
+
+---
+
+## ADR-014: 분석 완료 후 문서 요약 카드 및 Citation 타입 확장
+
+**날짜**: 2026-04-15
+
+**결정**:
+- `RiskAnalysis` 인터페이스에 `documentSummary: string | null`, `overallRisk: "HIGH" | "MEDIUM" | "LOW" | null`, `keyIssues: string[] | null` 필드를 추가한다.
+- 계약 뷰어 페이지에서 `analysis.status === "completed"` && `analysis.documentSummary` 존재 시 PDF 뷰어 위에 요약 카드를 인라인으로 렌더링한다.
+- `keyIssues`는 API가 JSON string으로 반환할 수 있으므로 try/catch 파싱을 적용한다. 최대 5개 표시.
+- `overallRisk`는 HIGH=red, MEDIUM=amber, LOW=green 색상 배지로 표시한다.
+- `Citation.type` 유니온에 `"prec" | "law"` 추가 (AI 워커 신규 타입 지원).
+- `CitationCard`의 `TYPE_LABEL`과 `TypeIcon`에 `prec`(판례, 저울 아이콘), `law`(법령, 책 아이콘) 케이스 추가.
+- `EvidencePanel`에서 `handleRetrieveMore`, `retrieving`, `retrieveError` 및 "증거 더 보기" 버튼 제거 — AI 워커가 `RETRIEVE_EVIDENCE` 메시지를 더 이상 처리하지 않아 DLQ 라우팅이 발생하기 때문.
+
+**이유**:
+- signsafe-api `risk_analyses` 테이블에 `document_summary`, `overall_risk`, `key_issues` 컬럼이 추가됨에 따라 프론트엔드에서 해당 데이터를 표시해야 함.
+- RAG 파이프라인 변경으로 AI 워커가 `prec`/`law` citation 타입을 반환하기 시작함.
+- "증거 더 보기" 기능은 워커 측 지원이 제거됐으므로 UI에서도 제거하여 사용자 혼동 방지.
+
+**영향**: 없음 (기존 API 응답과 하위 호환 — 새 필드는 nullable이므로 기존 분석 결과도 카드 없이 정상 동작)
 
 ---
 

--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -607,6 +607,67 @@ export default function ContractViewerPage({
           </div>
         )}
 
+        {/* Document summary card — shown after analysis completes with a summary */}
+        {analysis?.status === "completed" && analysis.documentSummary && (() => {
+          // Parse keyIssues: the API may return a JSON-encoded string or a real array.
+          let issues: string[] = [];
+          if (Array.isArray(analysis.keyIssues)) {
+            issues = analysis.keyIssues;
+          } else if (typeof analysis.keyIssues === "string") {
+            try {
+              const parsed: unknown = JSON.parse(analysis.keyIssues);
+              if (Array.isArray(parsed)) {
+                issues = parsed.filter((x): x is string => typeof x === "string");
+              }
+            } catch {
+              // Unparseable — leave issues empty.
+            }
+          }
+
+          const riskBadge: Record<string, { label: string; cls: string }> = {
+            HIGH:   { label: "고위험",   cls: "bg-red-50   text-red-700   ring-red-200"   },
+            MEDIUM: { label: "중간위험", cls: "bg-amber-50 text-amber-700 ring-amber-200" },
+            LOW:    { label: "저위험",   cls: "bg-green-50 text-green-700 ring-green-200" },
+          };
+          const badge = analysis.overallRisk ? riskBadge[analysis.overallRisk] : null;
+
+          return (
+            <div className="mx-4 mt-4 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-4 space-y-3">
+              {/* Header row */}
+              <div className="flex items-center gap-2">
+                <svg className="h-4 w-4 flex-shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <span className="text-xs font-semibold text-zinc-600 uppercase tracking-wide">문서 요약</span>
+                {badge && (
+                  <span className={`ml-auto rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset ${badge.cls}`}>
+                    {badge.label}
+                  </span>
+                )}
+              </div>
+
+              {/* Summary text */}
+              <p className="text-sm text-zinc-700 leading-relaxed">{analysis.documentSummary}</p>
+
+              {/* Key issues */}
+              {issues.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide">주요 이슈</p>
+                  <ul className="space-y-1">
+                    {issues.slice(0, 5).map((issue, i) => (
+                      <li key={i} className="flex items-start gap-2 text-xs text-zinc-600">
+                        <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-zinc-400" />
+                        {issue}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          );
+        })()}
+
         {/* PDF content — shown when not processing (failed state still shows PDF) */}
         {!isDocumentProcessing && (
           pdfBlobUrl ? (

--- a/src/components/evidence/CitationCard.tsx
+++ b/src/components/evidence/CitationCard.tsx
@@ -16,11 +16,14 @@ const TYPE_LABEL: Record<string, string> = {
   policy: "정책",
   guideline: "가이드라인",
   clause: "유사 조항",
+  prec: "판례",
+  law: "법령",
 };
 
 // Type icon — SVG only
 function TypeIcon({ type }: { type: string }) {
-  if (type === "case") {
+  // Scale of justice icon — used for case law (case) and precedent (prec)
+  if (type === "case" || type === "prec") {
     return (
       <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
@@ -33,6 +36,15 @@ function TypeIcon({ type }: { type: string }) {
       <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
           d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+      </svg>
+    );
+  }
+  // Book-open icon — used for statutory law (law)
+  if (type === "law") {
+    return (
+      <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
       </svg>
     );
   }

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -127,8 +127,6 @@ export default function EvidencePanel({
 }: EvidencePanelProps) {
   const [evidenceSet, setEvidenceSet] = useState<EvidenceSet | null>(null);
   const [loadState, setLoadState] = useState<EvidenceLoadState>("idle");
-  const [retrieving, setRetrieving] = useState(false);
-  const [retrieveError, setRetrieveError] = useState(false);
   const [showOverride, setShowOverride] = useState(false);
 
   const effectiveLevel: RiskLevel =
@@ -152,21 +150,6 @@ export default function EvidencePanel({
       })
       .catch(() => setLoadState("error"));
   }, [evidenceSetId]);
-
-  async function handleRetrieveMore() {
-    if (!evidenceSetId) return;
-    setRetrieving(true);
-    setRetrieveError(false);
-    try {
-      await api.retrieveEvidence(evidenceSetId, 10);
-      const updated = await api.getEvidenceSet(evidenceSetId);
-      setEvidenceSet(updated);
-    } catch {
-      setRetrieveError(true);
-    } finally {
-      setRetrieving(false);
-    }
-  }
 
   const citations = evidenceSet ? parseCitations(evidenceSet.citations) : [];
   const actions = evidenceSet ? parseActions(evidenceSet.recommendedActions) : [];
@@ -287,25 +270,6 @@ export default function EvidencePanel({
                           contractId={contractId}
                         />
                       ))}
-                    </div>
-                    <div className="mt-3 space-y-1">
-                      <button
-                        onClick={handleRetrieveMore}
-                        disabled={retrieving}
-                        className="flex items-center gap-1.5 text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50"
-                      >
-                        {retrieving ? (
-                          <>
-                            <span className="h-3 w-3 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-500" />
-                            더 불러오는 중…
-                          </>
-                        ) : (
-                          "증거 더 보기"
-                        )}
-                      </button>
-                      {retrieveError && (
-                        <p className="text-xs text-red-500">증거를 불러오지 못했습니다. 다시 시도해 주세요.</p>
-                      )}
                     </div>
                   </div>
                 )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,7 +18,6 @@ import type {
   RiskAnalysisResponse,
   CreateAnalysisResponse,
   EvidenceSet,
-  RetrieveEvidenceResponse,
   RiskOverride,
   AuditEvent,
   UpdateContractRequest,
@@ -513,19 +512,7 @@ async function getEvidenceSet(evidenceSetId: string): Promise<EvidenceSet> {
   return request<EvidenceSet>(`/evidence-sets/${evidenceSetId}`);
 }
 
-async function retrieveEvidence(
-  evidenceSetId: string,
-  topK = 5,
-  filterParams = ""
-): Promise<RetrieveEvidenceResponse> {
-  return request<RetrieveEvidenceResponse>(
-    `/evidence-sets/${evidenceSetId}/retrieve`,
-    {
-      method: "POST",
-      body: JSON.stringify({ topK, filterParams }),
-    }
-  );
-}
+
 
 // ─────────────────────────────────────────────
 // Audit endpoints
@@ -638,7 +625,6 @@ export const api = {
 
   // Evidence
   getEvidenceSet,
-  retrieveEvidence,
 
   // Audit
   createAuditEvent,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -189,6 +189,12 @@ export interface RiskAnalysis {
   completedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  /** AI-generated plain-text summary of the entire document. Null until analysis completes. */
+  documentSummary: string | null;
+  /** Overall risk level for the document. Null until analysis completes. */
+  overallRisk: "HIGH" | "MEDIUM" | "LOW" | null;
+  /** Top-level issues identified by AI. May be a JSON-encoded string array from the API. Null until analysis completes. */
+  keyIssues: string[] | null;
 }
 
 export interface ClauseResult {
@@ -230,7 +236,7 @@ export interface CreateAnalysisResponse {
 // ─────────────────────────────────────────────
 export interface Citation {
   id: string;
-  type: "case" | "policy" | "guideline" | "clause";
+  type: "case" | "policy" | "guideline" | "clause" | "prec" | "law";
   title: string;
   snippet: string;
   whyRelevant: string;


### PR DESCRIPTION
## 변경사항

- **`src/types/index.ts`** — `RiskAnalysis`에 `documentSummary`, `overallRisk`, `keyIssues` 필드 추가; `Citation.type`에 `"prec" | "law"` 추가
- **`src/app/(app)/contracts/[id]/page.tsx`** — 분석 완료 시 PDF 뷰어 위에 문서 요약 카드 인라인 렌더링 (`showAnalysisCta` 배너 아래 위치)
  - `overallRisk` → HIGH/MEDIUM/LOW 색상 배지 (red/amber/green)
  - `documentSummary` → 요약 텍스트
  - `keyIssues` → 최대 5개 불릿 리스트 (JSON string 자동 파싱)
- **`src/components/evidence/CitationCard.tsx`** — `prec`(판례, 저울 아이콘), `law`(법령, 책 아이콘) 케이스 추가
- **`src/components/evidence/EvidencePanel.tsx`** — `handleRetrieveMore`, `retrieving`, `retrieveError` 상태 및 "증거 더 보기" 버튼 제거 (AI 워커 RETRIEVE_EVIDENCE 지원 중단으로 DLQ 라우팅 방지)
- **`src/lib/api.ts`** — `retrieveEvidence` 함수 및 export 제거
- **`DECISIONS.md`** — ADR-014 추가

## QA 결과

- `tsc --noEmit` — PASS (오류 없음)

Closes #128