### PR TITLE
fix(#131): EvidenceSet citations/recommendedActions 타입 수정 — parseCitations 제거

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { api } from "@/lib/api";
-import type { ClauseResult, EvidenceSet, Citation, RiskLevel } from "@/types";
+import type { ClauseResult, EvidenceSet, RiskLevel } from "@/types";
 import RiskBadge from "@/components/risk/RiskBadge";
 import CitationCard from "@/components/evidence/CitationCard";
 import OverrideDialog from "@/components/risk/OverrideDialog";
@@ -18,22 +18,6 @@ interface EvidencePanelProps {
 }
 
 type EvidenceLoadState = "idle" | "loading" | "success" | "error";
-
-function parseCitations(raw: string): Citation[] {
-  try {
-    return JSON.parse(raw) as Citation[];
-  } catch {
-    return [];
-  }
-}
-
-function parseActions(raw: string): string[] {
-  try {
-    return JSON.parse(raw) as string[];
-  } catch {
-    return [];
-  }
-}
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -151,8 +135,8 @@ export default function EvidencePanel({
       .catch(() => setLoadState("error"));
   }, [evidenceSetId]);
 
-  const citations = evidenceSet ? parseCitations(evidenceSet.citations) : [];
-  const actions = evidenceSet ? parseActions(evidenceSet.recommendedActions) : [];
+  const citations = evidenceSet?.citations ?? [];
+  const actions = evidenceSet?.recommendedActions ?? [];
 
   return (
     <AnimatePresence>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -248,10 +248,10 @@ export interface EvidenceSet {
   id: string;
   clauseResultId: string;
   rationale: string;
-  citations: string; // JSON string of Citation[]
-  recommendedActions: string; // JSON string of string[]
+  citations: Citation[];
+  recommendedActions: string[];
   topK: number;
-  filterParams: string;
+  filterParams: Record<string, unknown>;
   retrievedAt: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 변경사항
- `EvidenceSet.citations`: `string` → `Citation[]`
- `EvidenceSet.recommendedActions`: `string` → `string[]`
- `EvidenceSet.filterParams`: `string` → `Record<string, unknown>`
- `parseCitations()`, `parseActions()` 함수 및 호출 제거

## 배경
signsafe-api PR signsafe-io/signsafe-api#126에서 `EvidenceSet` Go 모델의
`Citations`/`RecommendedActions`/`FilterParams`를 `json.RawMessage`로 변경하여
API 응답에서 이제 올바른 JSON 배열/객체로 직렬화됨.
더이상 프론트엔드에서 `JSON.parse` 워크어라운드가 필요하지 않음.

## QA 결과
- TypeScript strict 타입 체크 통과

Closes #131