### PR TITLE
feat(#133): Citation court/date 필드 추가 및 CitationCard에 법원명·선고일 표시

### DIFF
--- a/src/components/evidence/CitationCard.tsx
+++ b/src/components/evidence/CitationCard.tsx
@@ -120,6 +120,13 @@ export default function CitationCard({ citation, contractId }: CitationCardProps
           {citation.title}
         </p>
 
+        {/* Court / date metadata — 판례/법령 only */}
+        {(citation.court || citation.date) && (
+          <p className="text-[11px] text-zinc-400 leading-snug">
+            {[citation.court, citation.date].filter(Boolean).join(" · ")}
+          </p>
+        )}
+
         {/* Snippet */}
         <p
           className={`text-xs text-zinc-500 leading-relaxed ${

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -242,6 +242,8 @@ export interface Citation {
   whyRelevant: string;
   source?: string;
   score?: number;
+  date?: string;
+  court?: string;
 }
 
 export interface EvidenceSet {


### PR DESCRIPTION
## 변경사항
- `Citation` 타입에 `court?: string`, `date?: string` 옵셔널 필드 추가
- `CitationCard` 제목 하단에 `법원명 · 선고일자` 표시 (값이 있을 때만)

## 배경
Python 워커(`analysis.py`)에서 RAG 검색 결과의 `court`, `date`를 이미 citations에 저장하고 있었으나 프론트엔드 타입에 정의되지 않아 UI에 전혀 표시되지 않았음.
판례 신뢰성 판단에 법원명과 선고일자는 중요한 맥락 정보.

Closes #133