### PR TITLE
feat(#135): 계약서 목록에 분석 위험도 배지 표시

### DIFF
--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -42,6 +42,12 @@ const STATUS_COLOR: Record<string, string> = {
 
 const STATUS_OPTIONS: ContractStatus[] = ["uploaded", "processing", "ready", "failed"];
 
+const RISK_BADGE: Record<string, { label: string; cls: string }> = {
+  HIGH:   { label: "고위험",   cls: "bg-red-50   text-red-700   ring-red-200"   },
+  MEDIUM: { label: "중간위험", cls: "bg-amber-50 text-amber-700 ring-amber-200" },
+  LOW:    { label: "저위험",   cls: "bg-green-50 text-green-700 ring-green-200" },
+};
+
 const PAGE_SIZE = 20;
 
 function DocIcon() {
@@ -607,6 +613,15 @@ function ContractsPageInner() {
                     </span>
                   );
                 })()}
+
+                {/* Analysis risk badge */}
+                {c.latestAnalysisRisk && RISK_BADGE[c.latestAnalysisRisk] && (
+                  <span
+                    className={`flex-shrink-0 hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${RISK_BADGE[c.latestAnalysisRisk].cls}`}
+                  >
+                    {RISK_BADGE[c.latestAnalysisRisk].label}
+                  </span>
+                )}
 
                 {/* Status badge */}
                 <span

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,8 @@ export interface Contract {
   expiresAt: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Populated by list queries only; null when no completed analysis exists. */
+  latestAnalysisRisk?: "HIGH" | "MEDIUM" | "LOW" | null;
 }
 
 export interface ContractListResponse {


### PR DESCRIPTION
## 변경사항
- `Contract` 타입에 `latestAnalysisRisk?: "HIGH" | "MEDIUM" | "LOW" | null` 추가
- 계약 목록 행에 위험도 배지 표시 (sm 이상 화면)
- signsafe-api PR signsafe-io/signsafe-api#128과 연동

## UI
- 분석 완료된 계약: 빨강(고위험) / 주황(중간위험) / 초록(저위험) 배지
- 미분석 계약: 배지 없음
- 위치: 만료 배지 ↔ 상태 배지 사이

Closes #135