### PR TITLE
feat(#139): 사이드바 레이아웃 전환 및 UI 디자인 리파인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# lock & config
+package-lock.json
+next.config.ts

--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -353,7 +353,7 @@ export default function ContractViewerPage({
   }
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)] overflow-hidden">
+    <div className="flex h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden">
       {/* Left: Clause navigation — desktop only */}
       <aside className="hidden w-64 flex-shrink-0 overflow-y-auto border-r border-zinc-200 bg-white md:block lg:w-72">
         {loadState === "loading" ? (

--- a/src/app/(app)/contracts/page.tsx
+++ b/src/app/(app)/contracts/page.tsx
@@ -34,10 +34,10 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const STATUS_COLOR: Record<string, string> = {
-  uploaded: "bg-zinc-100 text-zinc-600 ring-zinc-200",
-  processing: "bg-amber-50 text-amber-700 ring-amber-200",
-  ready: "bg-green-50 text-green-700 ring-green-200",
-  failed: "bg-red-50 text-red-600 ring-red-200",
+  uploaded: "text-zinc-600 ring-zinc-300",
+  processing: "text-amber-700 ring-amber-300",
+  ready: "text-green-600 ring-green-400",
+  failed: "text-red-500 ring-red-300",
 };
 
 const STATUS_OPTIONS: ContractStatus[] = ["uploaded", "processing", "ready", "failed"];
@@ -292,11 +292,11 @@ function ContractsPageInner() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:px-6 sm:py-10 space-y-8">
+    <div className="mx-auto w-full max-w-4xl px-6 py-8 space-y-5">
       {/* Page header */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold text-zinc-900">계약서</h1>
+          <h1 className="text-base font-bold text-zinc-900">계약서</h1>
           {loadState === "success" && (
             <p className="mt-0.5 text-sm text-zinc-400">
               총 {total}건
@@ -309,10 +309,10 @@ function ContractsPageInner() {
         <button
           onClick={() => setShowUpload((v) => !v)}
           className={[
-            "cursor-pointer inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+            "cursor-pointer inline-flex items-center gap-1.5 rounded-xl px-4 py-2 text-sm font-medium transition-colors",
             showUpload
               ? "bg-zinc-100 text-zinc-900 hover:bg-zinc-200"
-              : "bg-zinc-900 text-white hover:bg-zinc-700",
+              : "bg-blue-600 text-white hover:bg-blue-700",
           ].join(" ")}
         >
           {showUpload ? (
@@ -498,7 +498,7 @@ function ContractsPageInner() {
           </p>
           <button
             onClick={() => setShowUpload(true)}
-            className="cursor-pointer mt-5 inline-flex items-center gap-1.5 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
+            className="cursor-pointer mt-5 inline-flex items-center gap-1.5 rounded-xl bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
           >
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -530,73 +530,66 @@ function ContractsPageInner() {
 
       {/* Contract list */}
       {loadState === "success" && contracts.length > 0 && (
-        <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
-          {/* Select-all header row */}
-          <div className="flex items-center gap-3 border-b border-zinc-100 px-5 py-2.5">
+        <div className="space-y-2">
+          {/* Select-all row */}
+          <div className="flex items-center gap-3 px-1 pb-1">
             <input
               type="checkbox"
               checked={allVisibleSelected}
               onChange={toggleSelectAll}
-              className="cursor-pointer h-4 w-4 rounded border-zinc-300 accent-zinc-900"
+              className="cursor-pointer h-4 w-4 rounded border-zinc-300 accent-blue-600"
               aria-label="모든 계약서 선택"
             />
-            <span className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+            <span className="text-xs font-medium text-zinc-400">
               {someSelected
                 ? `${selectedIds.size}개 선택됨`
                 : `총 ${contracts.length}건`}
             </span>
           </div>
 
-          {contracts.map((c, i) => (
+          {contracts.map((c) => (
             <div
               key={c.id}
               className={[
-                "relative flex items-center group",
-                i > 0 ? "border-t border-zinc-100" : "",
-                selectedIds.has(c.id) ? "bg-zinc-50" : "",
+                "group relative flex items-center rounded-2xl bg-white shadow-sm transition-shadow hover:shadow-md",
+                selectedIds.has(c.id) ? "ring-2 ring-blue-200" : "",
               ].join(" ")}
             >
               {/* Checkbox */}
-              <div className="pl-5 pr-2 flex-shrink-0">
+              <div className="pl-4 pr-2 flex-shrink-0">
                 <input
                   type="checkbox"
                   checked={selectedIds.has(c.id)}
                   onChange={() => toggleSelectOne(c.id)}
                   onClick={(e) => e.stopPropagation()}
-                  className="cursor-pointer h-4 w-4 rounded border-zinc-300 accent-zinc-900"
+                  className="cursor-pointer h-4 w-4 rounded border-zinc-300 accent-blue-600"
                   aria-label={`Select ${c.title}`}
                 />
               </div>
 
               <Link
                 href={`/contracts/${c.id}`}
-                className="flex flex-1 items-center gap-4 px-3 py-4 transition-colors hover:bg-zinc-50 min-w-0"
+                className="flex flex-1 items-center gap-4 px-3 py-4 min-w-0"
               >
-                {/* File icon */}
-                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-zinc-100 transition-colors group-hover:bg-zinc-200">
-                  <DocIcon />
-                </div>
-
-                {/* Title + meta */}
+                {/* Title + extension */}
                 <div className="flex-1 min-w-0">
-                  <p className="truncate text-sm font-medium text-zinc-900 leading-snug">
+                  <p className="truncate text-sm font-semibold text-zinc-900 leading-snug">
                     {c.title}
+                    {c.fileName && (
+                      <span className="ml-1 text-xs font-normal text-zinc-400">
+                        .{c.fileName.split(".").pop()?.toUpperCase() ?? "PDF"}
+                      </span>
+                    )}
                   </p>
-                  <div className="mt-0.5 flex items-center gap-1.5 text-xs text-zinc-400 min-w-0">
-                    <span className="truncate">{c.fileName}</span>
-                    {c.fileSize ? (
-                      <span className="flex-shrink-0 hidden sm:inline">
-                        &middot; {formatBytes(c.fileSize)}
-                      </span>
-                    ) : null}
-                    {c.createdAt ? (
-                      <span className="flex-shrink-0 hidden md:inline">
-                        &middot; {formatDate(c.createdAt)}
-                      </span>
-                    ) : null}
-                  </div>
+                  {c.fileSize ? (
+                    <p className="mt-0.5 text-xs text-zinc-400 hidden sm:block">
+                      {formatBytes(c.fileSize)}
+                    </p>
+                  ) : null}
                 </div>
 
+                {/* Right side: expiry, status, date */}
+                <div className="flex flex-shrink-0 items-center gap-3">
                 {/* Expiry badge */}
                 {(() => {
                   const expiryStatus = getExpiryStatus(c.expiresAt);
@@ -605,8 +598,8 @@ function ContractsPageInner() {
                     <span
                       className={
                         expiryStatus === "expired"
-                          ? "flex-shrink-0 hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 bg-red-50 text-red-600 ring-red-200"
-                          : "flex-shrink-0 hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 bg-orange-50 text-orange-600 ring-orange-200"
+                          ? "hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 text-red-600 ring-red-300"
+                          : "hidden sm:inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 text-orange-600 ring-orange-300"
                       }
                     >
                       {expiryStatus === "expired" ? "만료됨" : "곧 만료"}
@@ -625,28 +618,25 @@ function ContractsPageInner() {
 
                 {/* Status badge */}
                 <span
-                  className={`flex-shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${
-                    STATUS_COLOR[c.status] ?? "bg-zinc-100 text-zinc-600 ring-zinc-200"
+                  className={`rounded-full px-3 py-1 text-xs font-medium ring-1 ${
+                    STATUS_COLOR[c.status] ?? "text-zinc-600 ring-zinc-300"
                   }`}
                 >
                   {STATUS_LABEL[c.status] ?? c.status}
                 </span>
 
-                {/* Chevron */}
-                <svg
-                  className="h-4 w-4 flex-shrink-0 text-zinc-300 transition-colors group-hover:text-zinc-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                </svg>
+                  {c.createdAt && (
+                    <span className="hidden md:block text-xs text-zinc-400">
+                      {formatDate(c.createdAt)}
+                    </span>
+                  )}
+                </div>
               </Link>
 
               {/* Delete button (visible on hover) */}
               <button
                 onClick={(e) => openDeleteDialog(e, c)}
-                className="cursor-pointer mr-4 flex-shrink-0 rounded-md p-1.5 text-zinc-300 opacity-0 group-hover:opacity-100 transition-all hover:bg-red-50 hover:text-red-500"
+                className="cursor-pointer mr-3 flex-shrink-0 rounded-lg p-1.5 text-zinc-300 opacity-0 group-hover:opacity-100 transition-all hover:bg-red-50 hover:text-red-500"
                 title="계약서 삭제"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -17,10 +17,10 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const STATUS_COLOR: Record<string, string> = {
-  uploaded: "bg-zinc-100 text-zinc-600 ring-zinc-200",
-  processing: "bg-amber-50 text-amber-700 ring-amber-200",
-  ready: "bg-green-50 text-green-700 ring-green-200",
-  failed: "bg-red-50 text-red-600 ring-red-200",
+  uploaded: "text-zinc-600 ring-zinc-300",
+  processing: "text-amber-700 ring-amber-300",
+  ready: "text-green-600 ring-green-400",
+  failed: "text-red-600 ring-red-300",
 };
 
 // ─── Expiry helpers ─────────────────────────────────────────────────────────
@@ -61,9 +61,10 @@ function ExpiryBadge({ expiresAt }: { expiresAt: string }) {
 
 function SkeletonCard() {
   return (
-    <div className="animate-pulse rounded-xl border border-zinc-200 bg-white p-5">
-      <div className="mb-2 h-3 w-24 rounded bg-zinc-100" />
-      <div className="h-8 w-16 rounded bg-zinc-100" />
+    <div className="animate-pulse rounded-2xl bg-white p-5 shadow-sm">
+      <div className="mb-3 h-10 w-10 rounded-xl bg-zinc-100" />
+      <div className="mb-2 h-3 w-20 rounded bg-zinc-100" />
+      <div className="h-7 w-12 rounded bg-zinc-100" />
     </div>
   );
 }
@@ -86,13 +87,11 @@ interface StatCardProps {
   accent?: string; // tailwind text colour class
 }
 
-function StatCard({ label, value, accent = "text-zinc-900" }: StatCardProps) {
+function StatCard({ label, value, accent = "text-zinc-800" }: StatCardProps) {
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
-      <p className="text-xs font-medium uppercase tracking-wide text-zinc-400">
-        {label}
-      </p>
-      <p className={`mt-1 text-3xl font-semibold tabular-nums ${accent}`}>
+    <div className="rounded-2xl bg-white p-5 shadow-sm">
+      <p className="text-sm text-zinc-500">{label}</p>
+      <p className={`mt-1 text-3xl font-bold tabular-nums ${accent}`}>
         {value.toLocaleString()}
       </p>
     </div>
@@ -147,15 +146,15 @@ function RiskBar({ high, medium, low }: RiskBarProps) {
 
       {/* Legend */}
       <div className="flex flex-wrap gap-4 text-xs">
-        <span className="flex items-center gap-1.5 text-zinc-600">
+        <span className="flex items-center gap-1.5 text-zinc-500">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-red-500" />
           높음 &mdash; {high} ({highPct}%)
         </span>
-        <span className="flex items-center gap-1.5 text-zinc-600">
+        <span className="flex items-center gap-1.5 text-zinc-500">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-amber-400" />
           중간 &mdash; {medium} ({medPct}%)
         </span>
-        <span className="flex items-center gap-1.5 text-zinc-600">
+        <span className="flex items-center gap-1.5 text-zinc-500">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-green-400" />
           낮음 &mdash; {low} ({lowPct}%)
         </span>
@@ -300,26 +299,10 @@ export default function DashboardPage() {
   }, [orgId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <div className="mx-auto w-full max-w-screen-xl px-4 py-8 sm:px-6">
-      {/* Page header */}
-      <div className="mb-8 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold text-zinc-900">대시보드</h1>
-          {user?.organizationName && (
-            <p className="mt-0.5 text-sm text-zinc-500">{user.organizationName}</p>
-          )}
-        </div>
-        <Link
-          href="/contracts"
-          className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
-        >
-          계약서 보기
-        </Link>
-      </div>
-
+    <div className="mx-auto w-full max-w-screen-xl px-6 py-8">
       {/* Error state */}
       {error && (
-        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {error}{" "}
           <button
             onClick={fetchStats}
@@ -332,9 +315,7 @@ export default function DashboardPage() {
 
       {/* Contract status cards */}
       <section className="mb-8">
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-400">
-          계약서 현황
-        </h2>
+        <h2 className="mb-4 text-base font-bold text-zinc-800">계약서 현황</h2>
         {loading ? (
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -377,9 +358,9 @@ export default function DashboardPage() {
       </section>
 
       {/* Bottom three-column section */}
-      <div className="grid gap-6 lg:grid-cols-3">
+      <div className="grid gap-5 lg:grid-cols-3">
         {/* Risk distribution */}
-        <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+        <section className="rounded-2xl bg-white p-5 shadow-sm">
           <div className="mb-4 flex items-center justify-between">
             <h2 className="text-sm font-semibold text-zinc-800">
               리스크 분포
@@ -405,14 +386,14 @@ export default function DashboardPage() {
         </section>
 
         {/* Recent contracts */}
-        <section className="rounded-xl border border-zinc-200 bg-white shadow-sm">
+        <section className="rounded-2xl bg-white shadow-sm">
           <div className="flex items-center justify-between border-b border-zinc-100 px-5 py-4">
             <h2 className="text-sm font-semibold text-zinc-800">
               최근 계약서
             </h2>
             <Link
               href="/contracts"
-              className="text-xs font-medium text-zinc-500 hover:text-zinc-800"
+              className="text-xs font-medium text-blue-500 hover:text-blue-700"
             >
               전체 보기
             </Link>
@@ -457,10 +438,7 @@ export default function DashboardPage() {
                     </span>
                     <div className="flex flex-shrink-0 items-center gap-3">
                       <span
-                        className={[
-                          "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
-                          STATUS_COLOR[c.status as ContractStatus] ?? STATUS_COLOR.uploaded,
-                        ].join(" ")}
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${STATUS_COLOR[c.status as ContractStatus] ?? STATUS_COLOR.uploaded}`}
                       >
                         {STATUS_LABEL[c.status] ?? c.status}
                       </span>
@@ -476,7 +454,7 @@ export default function DashboardPage() {
         </section>
 
         {/* Expiring soon widget */}
-        <section className="rounded-xl border border-zinc-200 bg-white shadow-sm">
+        <section className="rounded-2xl bg-white shadow-sm">
           <div className="flex items-center justify-between border-b border-zinc-100 px-5 py-4">
             <h2 className="text-sm font-semibold text-zinc-800">
               만료 임박
@@ -530,14 +508,14 @@ export default function DashboardPage() {
       </div>
 
       {/* Expiry timeline section — 30/60/90-day buckets */}
-      <section className="mt-6 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <section className="mt-5 rounded-2xl bg-white p-5 shadow-sm">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-sm font-semibold text-zinc-800">
             만료 일정
           </h2>
           <Link
             href="/contracts?status=ready"
-            className="text-xs font-medium text-zinc-500 hover:text-zinc-800"
+            className="text-xs font-medium text-blue-500 hover:text-blue-700"
           >
             계약서 관리
           </Link>

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,18 +1,87 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { OrgSwitcher } from "@/components/ui/OrgSwitcher";
 
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+function DashboardIcon() {
+  return (
+    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75}
+        d="M4 5a1 1 0 011-1h4a1 1 0 011 1v5a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v2a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zM14 13a1 1 0 011-1h4a1 1 0 011 1v6a1 1 0 01-1 1h-4a1 1 0 01-1-1v-6z"
+      />
+    </svg>
+  );
+}
+
+function ContractIcon() {
+  return (
+    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75}
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+      />
+    </svg>
+  );
+}
+
+function AuditIcon() {
+  return (
+    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75}
+        d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+      />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75}
+        d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+      />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75}
+        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+  );
+}
+
+function LogoutIcon() {
+  return (
+    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75}
+        d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+      />
+    </svg>
+  );
+}
+
+function MenuIcon() {
+  return (
+    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
+  );
+}
+
+// ── Nav link ──────────────────────────────────────────────────────────────────
+
 function NavLink({
   href,
+  icon,
   children,
+  onClick,
 }: {
   href: string;
+  icon: React.ReactNode;
   children: React.ReactNode;
+  onClick?: () => void;
 }) {
   const pathname = usePathname();
   const isActive = pathname === href || pathname.startsWith(href + "/");
@@ -20,33 +89,102 @@ function NavLink({
   return (
     <Link
       href={href}
+      onClick={onClick}
       className={[
-        "relative text-sm font-medium transition-colors duration-150",
+        "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
         isActive
-          ? "text-zinc-900"
-          : "text-zinc-500 hover:text-zinc-800",
+          ? "bg-blue-50 text-blue-600"
+          : "text-zinc-500 hover:bg-zinc-50 hover:text-zinc-800",
       ].join(" ")}
     >
+      <span className={isActive ? "text-blue-600" : "text-zinc-400"}>
+        {icon}
+      </span>
       {children}
-      {isActive && (
-        <span className="absolute -bottom-[1px] left-0 right-0 h-[2px] rounded-full bg-zinc-900" />
-      )}
     </Link>
   );
 }
 
+// ── Sidebar ───────────────────────────────────────────────────────────────────
+
+function Sidebar({
+  user,
+  onLogout,
+  onClose,
+}: {
+  user: ReturnType<typeof useAuthStore>["user"];
+  onLogout: () => void;
+  onClose?: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      {/* Logo */}
+      <div className="flex h-16 flex-shrink-0 items-center gap-2.5 px-5">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-600">
+          <svg className="h-5 w-5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+          </svg>
+        </div>
+        <span className="text-base font-bold text-blue-600">SignSafe</span>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex-1 space-y-0.5 px-3 py-2">
+        <NavLink href="/dashboard" icon={<DashboardIcon />} onClick={onClose}>
+          대시보드
+        </NavLink>
+        <NavLink href="/contracts" icon={<ContractIcon />} onClick={onClose}>
+          계약서
+        </NavLink>
+        {user?.permissions?.includes("audit:read") && (
+          <NavLink href="/audit-logs" icon={<AuditIcon />} onClick={onClose}>
+            감사 로그
+          </NavLink>
+        )}
+      </nav>
+
+      {/* Bottom section */}
+      <div className="flex-shrink-0 space-y-1 border-t border-zinc-100 px-3 py-4">
+        <div className="px-3 pb-1">
+          <OrgSwitcher />
+        </div>
+        {user && (
+          <div className="truncate px-3 pb-1 text-xs text-zinc-400">
+            {user.fullName}
+          </div>
+        )}
+        <NavLink href="/settings" icon={<SettingsIcon />} onClick={onClose}>
+          설정
+        </NavLink>
+        <button
+          onClick={onLogout}
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-800"
+        >
+          <span className="text-zinc-400">
+            <LogoutIcon />
+          </span>
+          로그아웃
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Layout ────────────────────────────────────────────────────────────────────
+
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const { accessToken, user, setAuth, clearAuth } = useAuthStore();
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
     if (accessToken) return;
 
     api
       .getMe()
-      .then((user) => {
+      .then((u) => {
         const token = useAuthStore.getState().accessToken ?? "";
-        setAuth(token, user);
+        setAuth(token, u);
       })
       .catch(() => {
         clearAuth();
@@ -64,101 +202,52 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-zinc-50">
-      {/* Top nav */}
-      <header className="sticky top-0 z-30 border-b border-zinc-200 bg-white">
-        <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between gap-4 px-4 sm:px-6">
-          {/* Left: logo + nav */}
-          <div className="flex items-center gap-6 min-w-0">
-            <Link
-              href="/contracts"
-              className="flex flex-shrink-0 items-center gap-2 text-sm font-semibold tracking-tight text-zinc-900"
-            >
-              {/* Shield icon */}
-              <svg
-                className="h-5 w-5 text-zinc-900"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
+    <div className="flex min-h-screen bg-zinc-50">
+      {/* Desktop sidebar */}
+      <aside className="fixed inset-y-0 left-0 z-30 hidden w-64 border-r border-zinc-200 bg-white lg:flex lg:flex-col">
+        <Sidebar user={user} onLogout={handleLogout} />
+      </aside>
+
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/30 lg:hidden"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+
+      {/* Mobile sidebar */}
+      <aside
+        className={[
+          "fixed inset-y-0 left-0 z-50 w-64 border-r border-zinc-200 bg-white transition-transform duration-200 lg:hidden",
+          mobileOpen ? "translate-x-0" : "-translate-x-full",
+        ].join(" ")}
+      >
+        <Sidebar user={user} onLogout={handleLogout} onClose={() => setMobileOpen(false)} />
+      </aside>
+
+      {/* Content area */}
+      <div className="flex min-h-screen flex-1 flex-col lg:ml-64">
+        {/* Mobile top bar */}
+        <header className="flex h-14 items-center gap-3 border-b border-zinc-200 bg-white px-4 lg:hidden">
+          <button
+            onClick={() => setMobileOpen(true)}
+            className="rounded-lg p-1.5 text-zinc-500 hover:bg-zinc-100"
+          >
+            <MenuIcon />
+          </button>
+          <div className="flex items-center gap-2">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-blue-600">
+              <svg className="h-4 w-4 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
               </svg>
-              <span className="hidden sm:inline">SignSafe</span>
-            </Link>
-
-            <nav className="flex items-center gap-5">
-              <NavLink href="/dashboard">대시보드</NavLink>
-              <NavLink href="/contracts">계약서</NavLink>
-              {user?.permissions?.includes("audit:read") && (
-                <NavLink href="/audit-logs">감사 로그</NavLink>
-              )}
-            </nav>
-          </div>
-
-          {/* Right: org switcher + user */}
-          <div className="flex flex-shrink-0 items-center gap-2 sm:gap-3">
-            <OrgSwitcher />
-
-            {user && (
-              <span className="hidden text-sm text-zinc-500 lg:inline truncate max-w-[120px]">
-                {user.fullName}
-              </span>
-            )}
-
-            <div className="flex items-center gap-1">
-              <Link
-                href="/settings"
-                className="cursor-pointer rounded-md px-2.5 py-1.5 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900"
-              >
-                <span className="hidden sm:inline">설정</span>
-                <svg
-                  className="h-4 w-4 sm:hidden"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-              </Link>
-              <button
-                onClick={handleLogout}
-                className="cursor-pointer rounded-md px-2.5 py-1.5 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900"
-              >
-                <span className="hidden sm:inline">로그아웃</span>
-                <svg
-                  className="h-4 w-4 sm:hidden"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-                  />
-                </svg>
-              </button>
             </div>
+            <span className="text-sm font-bold text-blue-600">SignSafe</span>
           </div>
-        </div>
-      </header>
+        </header>
 
-      <main className="flex flex-1 flex-col">{children}</main>
+        <main className="flex flex-1 flex-col">{children}</main>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -39,7 +39,7 @@ export default function SettingsLayout({
   return (
     <div className="flex flex-col">
       {/* Sticky tab bar */}
-      <div className="sticky top-14 z-20 border-b border-zinc-200 bg-white">
+      <div className="sticky top-14 lg:top-0 z-20 border-b border-zinc-200 bg-white">
         <div className="mx-auto flex max-w-3xl gap-6 px-4 pt-5 sm:px-6">
           <SettingsTab href="/settings">계정</SettingsTab>
           <SettingsTab href="/settings/organization">조직</SettingsTab>

--- a/src/components/ui/SettingsUI.tsx
+++ b/src/components/ui/SettingsUI.tsx
@@ -51,14 +51,14 @@ interface SectionProps {
 
 export function Section({ title, description, children }: SectionProps) {
   return (
-    <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
-      <div className="border-b border-zinc-100 px-6 py-5">
-        <h2 className="text-sm font-semibold text-zinc-900">{title}</h2>
+    <div className="overflow-hidden rounded-2xl bg-zinc-100 shadow-sm">
+      <div className="px-6 pt-5 pb-4">
+        <h2 className="text-base font-bold text-zinc-900">{title}</h2>
         {description && (
           <p className="mt-0.5 text-sm text-zinc-500">{description}</p>
         )}
       </div>
-      <div className="px-6 py-6">{children}</div>
+      <div className="px-6 pb-6">{children}</div>
     </div>
   );
 }
@@ -82,7 +82,7 @@ export function Field({ label, children }: FieldProps) {
 // ── Shared class strings ──────────────────────────────────────────────────────
 
 export const inputCls =
-  "w-full rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10 disabled:opacity-50 disabled:bg-zinc-50";
+  "w-full rounded-xl border border-transparent bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10 disabled:opacity-50 disabled:bg-zinc-50";
 
 export const primaryBtnCls =
-  "inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50";
+  "inline-flex items-center gap-2 rounded-xl bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50";

--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -284,7 +284,7 @@ export default function ClauseNav({
                       {clause.pageStart > 0 && (
                         <span
                           className={`mt-0.5 block text-xs ${
-                            isSelected ? "text-zinc-400" : "text-zinc-400"
+                            isSelected ? "text-zinc-300" : "text-zinc-400"
                           }`}
                         >
                           p.&nbsp;{clause.pageStart}


### PR DESCRIPTION
## Summary
- 상단 네비게이션 → 사이드바 레이아웃 전환 (데스크톱 고정 + 모바일 슬라이드)
- 대시보드·계약서 목록·설정 카드 스타일 통일 (보더 제거, 둥근 모서리, 블루 액센트)
- 상태 배지·버튼 색상 정리
- gitignore에 package-lock.json, next.config.ts 추가

Closes #139

## Test plan
- [ ] 데스크톱에서 사이드바 정상 표시 확인
- [ ] 모바일에서 햄버거 메뉴 → 사이드바 슬라이드 동작 확인
- [ ] 대시보드, 계약서 목록, 설정 페이지 UI 확인
- [ ] 계약서 상세 페이지 높이 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)