### PR TITLE
fix(#141): layout.tsx Sidebar user 타입 에러 수정

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import { useAuthStore } from "@/lib/auth";
+import type { User } from "@/types";
 import { api } from "@/lib/api";
 import { OrgSwitcher } from "@/components/ui/OrgSwitcher";
 
@@ -112,7 +113,7 @@ function Sidebar({
   onLogout,
   onClose,
 }: {
-  user: ReturnType<typeof useAuthStore>["user"];
+  user: User | null;
   onLogout: () => void;
   onClose?: () => void;
 }) {


### PR DESCRIPTION
## Summary
- Sidebar 컴포넌트의 user prop 타입을 `ReturnType<typeof useAuthStore>["user"]` → `User | null`로 수정
- Zustand 5에서 ReturnType이 unknown으로 추론되어 빌드 실패하던 문제 해결

Closes #141

## Test plan
- [ ] `npm run build` 성공 확인
- [ ] xquare 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)