### PR TITLE
feat(#145): PDF 하이라이트 클릭 시 근거 패널 표시

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -124,7 +124,11 @@ export default function EvidencePanel({
     typeof clauseResult.confidence === "number" ? clauseResult.confidence : 0.5;
 
   useEffect(() => {
-    if (!evidenceSetId) return;
+    setEvidenceSet(null);
+    if (!evidenceSetId) {
+      setLoadState("idle");
+      return;
+    }
     setLoadState("loading");
     api
       .getEvidenceSet(evidenceSetId)

--- a/src/components/risk/RiskOverlay.tsx
+++ b/src/components/risk/RiskOverlay.tsx
@@ -46,7 +46,7 @@ export default function RiskOverlay({
 
   return (
     <div
-      className="pointer-events-none absolute inset-0"
+      className="pointer-events-none absolute inset-0 z-10"
       style={{ width: pageWidth, height: pageHeight }}
     >
       {visible.map((r) => {
@@ -63,7 +63,7 @@ export default function RiskOverlay({
         return (
           <div
             key={r.id}
-            className="pointer-events-auto absolute cursor-pointer"
+            className="pointer-events-auto absolute cursor-pointer transition-opacity hover:opacity-80 group"
             style={{
               left: x,
               top: y,
@@ -74,8 +74,16 @@ export default function RiskOverlay({
               borderRadius: 3,
             }}
             onClick={() => onClauseClick?.(r)}
-            title={`${effectiveLevel} risk${r.issueType ? ` — ${r.issueType}` : ""}`}
-          />
+            title={r.issueType ? `${r.issueType} — 클릭하여 근거 보기` : "클릭하여 근거 보기"}
+          >
+            {/* Click hint icon */}
+            <div className="absolute -top-5 left-0 hidden group-hover:flex items-center gap-1 rounded bg-zinc-800/90 px-1.5 py-0.5 text-[10px] text-white whitespace-nowrap shadow-sm pointer-events-none">
+              <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              근거 보기
+            </div>
+          </div>
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- `RiskOverlay`에 `z-10` 추가 — react-pdf 텍스트 레이어가 클릭을 가로채던 문제 해결
- 하이라이트 hover 시 '근거 보기' 툴팁 표시 (클릭 가능함을 시각적으로 안내)
- `EvidencePanel`에서 `evidenceSetId` 변경 시 이전 evidence 즉시 초기화 (조항 전환 시 잠깐 이전 내용 보이던 문제 해결)

Closes #145

## Test plan
- [ ] PDF 하이라이트 클릭 시 EvidencePanel 열림 확인
- [ ] 다른 하이라이트 클릭 시 패널 내용이 올바르게 전환되는지 확인
- [ ] 하이라이트 hover 시 툴팁 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)