### PR TITLE
feat(#147): 선택된 조항 PDF 하이라이트 강조 표시

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -674,6 +674,7 @@ export default function ContractViewerPage({
             <DocumentViewer
               fileUrl={pdfBlobUrl}
               clauseResults={clauseResults}
+              selectedClauseId={selectedClauseId}
               onClauseClick={handleClauseClick}
               scrollTargetRef={scrollTargetRef}
             />

--- a/src/components/risk/RiskOverlay.tsx
+++ b/src/components/risk/RiskOverlay.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import type { ClauseResult, RiskLevel } from "@/types";
 
 interface RiskOverlayProps {
@@ -8,6 +9,7 @@ interface RiskOverlayProps {
   /** Page dimensions from react-pdf (in CSS pixels) */
   pageWidth: number;
   pageHeight: number;
+  selectedClauseId?: string;
   onClauseClick?: (result: ClauseResult) => void;
 }
 
@@ -30,8 +32,19 @@ export default function RiskOverlay({
   pageNumber,
   pageWidth,
   pageHeight,
+  selectedClauseId,
   onClauseClick,
 }: RiskOverlayProps) {
+  const [pulsingId, setPulsingId] = useState<string | null>(null);
+  const prevSelectedRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!selectedClauseId || selectedClauseId === prevSelectedRef.current) return;
+    prevSelectedRef.current = selectedClauseId;
+    setPulsingId(selectedClauseId);
+    const t = setTimeout(() => setPulsingId(null), 1200);
+    return () => clearTimeout(t);
+  }, [selectedClauseId]);
   // Filter results that have coordinates and belong to this page.
   const visible = clauseResults.filter(
     (r) =>
@@ -60,29 +73,45 @@ export default function RiskOverlay({
         const effectiveLevel: RiskLevel =
           (r.overriddenRiskLevel as RiskLevel | null) ?? r.riskLevel;
 
+        const isSelected = r.clauseId === selectedClauseId;
+        const isPulsing = r.clauseId === pulsingId;
+
         return (
           <div
             key={r.id}
-            className="pointer-events-auto absolute cursor-pointer transition-opacity hover:opacity-80 group"
+            className={[
+              "pointer-events-auto absolute cursor-pointer transition-all duration-200 group",
+              isSelected ? "opacity-100" : "opacity-70 hover:opacity-90",
+              isPulsing ? "animate-pulse" : "",
+            ].join(" ")}
             style={{
               left: x,
               top: y,
               width: w,
               height: h,
-              backgroundColor: RISK_COLORS[effectiveLevel],
-              border: `1.5px solid ${RISK_BORDER[effectiveLevel]}`,
+              backgroundColor: isSelected
+                ? RISK_COLORS[effectiveLevel].replace(/[\d.]+\)$/, "0.45)")
+                : RISK_COLORS[effectiveLevel],
+              border: isSelected
+                ? `2.5px solid ${RISK_BORDER[effectiveLevel]}`
+                : `1.5px solid ${RISK_BORDER[effectiveLevel]}`,
               borderRadius: 3,
+              boxShadow: isSelected
+                ? `0 0 0 2px ${RISK_BORDER[effectiveLevel].replace(/[\d.]+\)$/, "0.35)")}`
+                : undefined,
             }}
             onClick={() => onClauseClick?.(r)}
             title={r.issueType ? `${r.issueType} — 클릭하여 근거 보기` : "클릭하여 근거 보기"}
           >
-            {/* Click hint icon */}
-            <div className="absolute -top-5 left-0 hidden group-hover:flex items-center gap-1 rounded bg-zinc-800/90 px-1.5 py-0.5 text-[10px] text-white whitespace-nowrap shadow-sm pointer-events-none">
-              <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              근거 보기
-            </div>
+            {/* Click hint (non-selected hover) */}
+            {!isSelected && (
+              <div className="absolute -top-5 left-0 hidden group-hover:flex items-center gap-1 rounded bg-zinc-800/90 px-1.5 py-0.5 text-[10px] text-white whitespace-nowrap shadow-sm pointer-events-none">
+                <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                근거 보기
+              </div>
+            )}
           </div>
         );
       })}

--- a/src/components/viewer/DocumentViewer.tsx
+++ b/src/components/viewer/DocumentViewer.tsx
@@ -26,6 +26,7 @@ interface DocumentViewerProps {
   /** URL or blob URL for the PDF file */
   fileUrl: string;
   clauseResults: ClauseResult[];
+  selectedClauseId?: string;
   onClauseClick?: (result: ClauseResult) => void;
   /** Ref map: clauseId → DOM element for scroll-to-clause */
   scrollTargetRef?: React.RefObject<Map<string, HTMLDivElement>>;
@@ -38,6 +39,7 @@ const PAGE_WIDTH = 680;
 export default function DocumentViewer({
   fileUrl,
   clauseResults,
+  selectedClauseId,
   onClauseClick,
   scrollTargetRef,
 }: DocumentViewerProps) {
@@ -119,6 +121,7 @@ export default function DocumentViewer({
                       pageNumber={pageNumber}
                       pageWidth={PAGE_WIDTH}
                       pageHeight={pageHeight}
+                      selectedClauseId={selectedClauseId}
                       onClauseClick={onClauseClick}
                     />
                   )}


### PR DESCRIPTION
## Summary
- `selectedClauseId`를 `page.tsx` → `DocumentViewer` → `RiskOverlay`로 prop 전달
- 선택된 조항 하이라이트: 배경 opacity 상승 + 테두리 2.5px + box-shadow ring 효과
- 선택 직후 1.2초 `animate-pulse`로 위치 명확히 안내, 이후 정적 강조 상태 유지
- 미선택 조항은 기본 opacity 낮게 + hover 시 올라오는 방식으로 대비 강조

Closes #147

## Test plan
- [ ] 사이드바에서 조항 클릭 시 PDF 해당 하이라이트 강조 확인
- [ ] PDF 하이라이트 직접 클릭 시도 동일 강조 확인
- [ ] pulse 1.2초 후 정적 강조로 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)