### PR TITLE
feat(#149): 하이라이트 기본 인용문 스타일, 클릭 시 전체 강조

### DIFF
--- a/src/components/risk/RiskOverlay.tsx
+++ b/src/components/risk/RiskOverlay.tsx
@@ -13,11 +13,18 @@ interface RiskOverlayProps {
   onClauseClick?: (result: ClauseResult) => void;
 }
 
-const RISK_COLORS: Record<RiskLevel, string> = {
-  HIGH: "rgba(239,68,68,0.25)",
-  MEDIUM: "rgba(249,115,22,0.22)",
-  LOW: "rgba(34,197,94,0.20)",
-  none: "rgba(161,161,170,0.15)",
+const RISK_BAR_COLOR: Record<RiskLevel, string> = {
+  HIGH: "rgba(239,68,68,0.85)",
+  MEDIUM: "rgba(249,115,22,0.85)",
+  LOW: "rgba(34,197,94,0.85)",
+  none: "rgba(161,161,170,0.6)",
+};
+
+const RISK_FILL: Record<RiskLevel, string> = {
+  HIGH: "rgba(239,68,68,0.18)",
+  MEDIUM: "rgba(249,115,22,0.16)",
+  LOW: "rgba(34,197,94,0.15)",
+  none: "rgba(161,161,170,0.12)",
 };
 
 const RISK_BORDER: Record<RiskLevel, string> = {
@@ -26,6 +33,8 @@ const RISK_BORDER: Record<RiskLevel, string> = {
   LOW: "rgba(34,197,94,0.7)",
   none: "rgba(161,161,170,0.5)",
 };
+
+const BAR_WIDTH = 3;
 
 export default function RiskOverlay({
   clauseResults,
@@ -42,10 +51,10 @@ export default function RiskOverlay({
     if (!selectedClauseId || selectedClauseId === prevSelectedRef.current) return;
     prevSelectedRef.current = selectedClauseId;
     setPulsingId(selectedClauseId);
-    const t = setTimeout(() => setPulsingId(null), 1200);
+    const t = setTimeout(() => setPulsingId(null), 1000);
     return () => clearTimeout(t);
   }, [selectedClauseId]);
-  // Filter results that have coordinates and belong to this page.
+
   const visible = clauseResults.filter(
     (r) =>
       r.pageNumber === pageNumber &&
@@ -63,8 +72,6 @@ export default function RiskOverlay({
       style={{ width: pageWidth, height: pageHeight }}
     >
       {visible.map((r) => {
-        // Coordinates from the API are relative (0-1 fractions of the page).
-        // Multiply by actual rendered page dimensions.
         const x = (r.highlightX ?? 0) * pageWidth;
         const y = (r.highlightY ?? 0) * pageHeight;
         const w = (r.highlightWidth ?? 0) * pageWidth;
@@ -80,8 +87,7 @@ export default function RiskOverlay({
           <div
             key={r.id}
             className={[
-              "pointer-events-auto absolute cursor-pointer transition-all duration-200 group",
-              isSelected ? "opacity-100" : "opacity-70 hover:opacity-90",
+              "pointer-events-auto absolute cursor-pointer group",
               isPulsing ? "animate-pulse" : "",
             ].join(" ")}
             style={{
@@ -89,21 +95,23 @@ export default function RiskOverlay({
               top: y,
               width: w,
               height: h,
-              backgroundColor: isSelected
-                ? RISK_COLORS[effectiveLevel].replace(/[\d.]+\)$/, "0.45)")
-                : RISK_COLORS[effectiveLevel],
+              // Smooth transition for all visual properties
+              transition: "background-color 200ms ease, border 200ms ease, box-shadow 200ms ease",
+              // Selected: full wrap. Default: transparent (bar rendered separately)
+              backgroundColor: isSelected ? RISK_FILL[effectiveLevel] : "transparent",
               border: isSelected
-                ? `2.5px solid ${RISK_BORDER[effectiveLevel]}`
-                : `1.5px solid ${RISK_BORDER[effectiveLevel]}`,
-              borderRadius: 3,
+                ? `1.5px solid ${RISK_BORDER[effectiveLevel]}`
+                : "none",
+              borderLeft: `${BAR_WIDTH}px solid ${RISK_BAR_COLOR[effectiveLevel]}`,
+              borderRadius: isSelected ? 3 : 0,
               boxShadow: isSelected
-                ? `0 0 0 2px ${RISK_BORDER[effectiveLevel].replace(/[\d.]+\)$/, "0.35)")}`
+                ? `0 0 0 1.5px ${RISK_BORDER[effectiveLevel].replace(/[\d.]+\)$/, "0.25)")}`
                 : undefined,
             }}
             onClick={() => onClauseClick?.(r)}
             title={r.issueType ? `${r.issueType} — 클릭하여 근거 보기` : "클릭하여 근거 보기"}
           >
-            {/* Click hint (non-selected hover) */}
+            {/* Hover tooltip (non-selected only) */}
             {!isSelected && (
               <div className="absolute -top-5 left-0 hidden group-hover:flex items-center gap-1 rounded bg-zinc-800/90 px-1.5 py-0.5 text-[10px] text-white whitespace-nowrap shadow-sm pointer-events-none">
                 <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- 기본 상태: 좌측 컬러 바(3px)만 표시 — Obsidian blockquote 스타일
- 선택 상태: 배경 fill + 전체 테두리 + box-shadow로 전체 감싸기
- 전환: 200ms ease transition + 선택 직후 1초 pulse
- 다른 조항 클릭 시 이전 조항 즉시 바 스타일로 복귀

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)