### PR TITLE
design: 로그인/회원가입 페이지 스타일을 앱 전반과 통일

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -18,7 +18,7 @@ export default function AuthLayout({
       <div className="relative w-full max-w-sm space-y-8">
         {/* Branding */}
         <div className="text-center">
-          <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-zinc-900 shadow-sm">
+          <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-600 shadow-sm">
             <svg
               className="h-6 w-6 text-white"
               viewBox="0 0 24 24"
@@ -31,7 +31,7 @@ export default function AuthLayout({
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold tracking-tight text-zinc-900">
+          <h1 className="text-2xl font-bold tracking-tight text-blue-600">
             SignSafe
           </h1>
           <p className="mt-1.5 text-sm text-zinc-500">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -68,17 +68,17 @@ export default function LoginPage() {
   }
 
   const inputCls =
-    "w-full rounded-lg border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+    "w-full rounded-xl border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
 
   return (
-    <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
+    <div className="animate-slide-in rounded-2xl bg-white px-8 py-8 shadow-sm">
       <div className="mb-7 text-center">
-        <h2 className="text-lg font-semibold text-zinc-900">다시 오셨군요</h2>
+        <h2 className="text-base font-bold text-zinc-900">다시 오셨군요</h2>
         <p className="mt-1 text-sm text-zinc-500">계정에 로그인하세요</p>
       </div>
 
       {formState.error && (
-        <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           <p>{formState.error}</p>
           {formState.showResend && (
             <div className="mt-2.5">
@@ -131,7 +131,7 @@ export default function LoginPage() {
             </label>
             <Link
               href="/forgot-password"
-              className="text-xs text-zinc-400 transition-colors hover:text-zinc-700"
+              className="text-xs font-medium text-blue-500 transition-colors hover:text-blue-700"
             >
               비밀번호를 잊으셨나요?
             </Link>
@@ -151,7 +151,7 @@ export default function LoginPage() {
         <button
           type="submit"
           disabled={formState.status === "loading"}
-          className="mt-1 w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-1 w-full rounded-xl bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {formState.status === "loading" ? (
             <span className="flex items-center justify-center gap-2">
@@ -168,7 +168,7 @@ export default function LoginPage() {
         계정이 없으신가요?{" "}
         <Link
           href="/signup"
-          className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+          className="font-semibold text-blue-600 transition-colors hover:text-blue-700"
         >
           회원가입
         </Link>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -48,11 +48,11 @@ export default function SignupPage() {
   }
 
   const inputCls =
-    "w-full rounded-lg border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+    "w-full rounded-xl border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
 
   if (formState.status === "success") {
     return (
-      <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-10 shadow-sm text-center space-y-4">
+      <div className="animate-slide-in rounded-2xl bg-white px-8 py-10 shadow-sm text-center space-y-4">
         <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
           <svg
             className="h-6 w-6 text-green-600"
@@ -69,7 +69,7 @@ export default function SignupPage() {
           </svg>
         </div>
         <div>
-          <h2 className="text-base font-semibold text-zinc-900">받은 편지함을 확인하세요</h2>
+          <h2 className="text-base font-bold text-zinc-900">받은 편지함을 확인하세요</h2>
           <p className="mt-2 text-sm text-zinc-500">
             <span className="font-medium text-zinc-900">{email}</span>으로
             인증 링크를 발송했습니다. 링크를 클릭하여 계정을 활성화하세요.
@@ -77,7 +77,7 @@ export default function SignupPage() {
         </div>
         <button
           onClick={() => router.push("/login")}
-          className="text-sm font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+          className="text-sm font-semibold text-blue-600 transition-colors hover:text-blue-700"
         >
           로그인으로 돌아가기
         </button>
@@ -86,14 +86,14 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="animate-slide-in rounded-2xl border border-zinc-200 bg-white px-8 py-8 shadow-sm">
+    <div className="animate-slide-in rounded-2xl bg-white px-8 py-8 shadow-sm">
       <div className="mb-7 text-center">
-        <h2 className="text-lg font-semibold text-zinc-900">계정 만들기</h2>
+        <h2 className="text-base font-bold text-zinc-900">계정 만들기</h2>
         <p className="mt-1 text-sm text-zinc-500">무료로 시작하세요</p>
       </div>
 
       {formState.error && (
-        <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {formState.error}
         </div>
       )}
@@ -177,14 +177,14 @@ export default function SignupPage() {
           <span className="text-sm text-zinc-600">
             <a
               href="/terms"
-              className="font-medium text-zinc-900 hover:underline"
+              className="font-medium text-blue-600 hover:text-blue-700 hover:underline"
             >
               이용약관
             </a>
             {" "}및{" "}
             <a
               href="/privacy"
-              className="font-medium text-zinc-900 hover:underline"
+              className="font-medium text-blue-600 hover:text-blue-700 hover:underline"
             >
               개인정보처리방침
             </a>
@@ -195,7 +195,7 @@ export default function SignupPage() {
         <button
           type="submit"
           disabled={formState.status === "loading"}
-          className="mt-1 w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-1 w-full rounded-xl bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {formState.status === "loading" ? (
             <span className="flex items-center justify-center gap-2">
@@ -212,7 +212,7 @@ export default function SignupPage() {
         이미 계정이 있으신가요?{" "}
         <Link
           href="/login"
-          className="font-semibold text-zinc-900 transition-colors hover:text-zinc-600"
+          className="font-semibold text-blue-600 transition-colors hover:text-blue-700"
         >
           로그인
         </Link>


### PR DESCRIPTION
## Summary
- 인증 페이지의 브랜드 컬러·카드·입력·버튼·링크 스타일을 앱 나머지 페이지의 디자인 언어와 일치시켰습니다.
- `(auth)/layout.tsx`의 로고·타이틀을 앱 사이드바와 동일한 `blue-600`으로 통일.
- 카드는 대시보드와 같은 `rounded-2xl bg-white shadow-sm` (테두리 제거), 입력/버튼은 설정 페이지와 동일한 `rounded-xl`로 변경.
- 헤딩은 `text-base font-bold`, 액션 링크는 `blue-500/600 → blue-700` 액센트로 맞춤.

## Test plan
- [ ] `/login`, `/signup`에서 브랜드 로고·타이틀이 파란색으로 노출되는지 확인
- [ ] 카드 테두리가 사라지고 그림자만 남은 모습이 대시보드 카드와 일관적인지 확인
- [ ] 입력 포커스, 버튼 hover/disabled, 로딩 스피너가 정상 동작하는지 확인
- [ ] "비밀번호를 잊으셨나요?", "회원가입/로그인", 이용약관/개인정보처리방침 링크가 파란 액센트로 보이는지 확인
- [ ] 회원가입 성공 화면·에러 알림 radius(`rounded-xl`)가 변경된 스타일과 맞는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)