### PR TITLE
design: 로그인/회원가입 UI/UX 전면 개편 (2-컬럼 스플릿 레이아웃)

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -4,23 +4,14 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-10 sm:py-12">
-      {/* Background subtle grid */}
-      <div
-        className="pointer-events-none fixed inset-0 opacity-[0.03]"
-        style={{
-          backgroundImage:
-            "linear-gradient(#18181b 1px, transparent 1px), linear-gradient(90deg, #18181b 1px, transparent 1px)",
-          backgroundSize: "40px 40px",
-        }}
-      />
-
-      <div className="relative w-full max-w-sm space-y-8">
-        {/* Branding */}
-        <div className="text-center">
-          <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-600 shadow-sm">
+    <div className="flex min-h-screen">
+      {/* Left brand panel */}
+      <div className="hidden lg:flex lg:w-[460px] xl:w-[520px] flex-shrink-0 flex-col justify-between bg-zinc-900 p-12">
+        {/* Logo */}
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-600 shadow-sm">
             <svg
-              className="h-6 w-6 text-white"
+              className="h-5 w-5 text-white"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
@@ -31,15 +22,93 @@ export default function AuthLayout({
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold tracking-tight text-blue-600">
-            SignSafe
-          </h1>
-          <p className="mt-1.5 text-sm text-zinc-500">
-            AI 기반 계약서 리스크 분석
-          </p>
+          <span className="text-lg font-bold text-white tracking-tight">SignSafe</span>
         </div>
 
-        {children}
+        {/* Center content */}
+        <div className="space-y-10">
+          <div>
+            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-blue-400">
+              AI 기반 계약 분석
+            </p>
+            <h2 className="text-4xl font-bold leading-tight text-white">
+              계약서의 숨겨진<br />위험을 발견하세요
+            </h2>
+            <p className="mt-4 text-base leading-relaxed text-zinc-400">
+              서명 전, AI가 리스크 조항을 자동으로 탐지하여
+              안전한 계약 체결을 도와드립니다.
+            </p>
+          </div>
+
+          {/* Features */}
+          <div className="space-y-5">
+            {[
+              {
+                icon: (
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.75}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+                  </svg>
+                ),
+                title: "AI 리스크 분석",
+                desc: "계약서의 불리한 조항과 위험 요소를 즉시 탐지",
+              },
+              {
+                icon: (
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.75}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+                  </svg>
+                ),
+                title: "감사 로그",
+                desc: "모든 계약 활동의 완전한 이력 추적 및 보관",
+              },
+              {
+                icon: (
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.75}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+                  </svg>
+                ),
+                title: "팀 협업",
+                desc: "조직 내 계약 검토 워크플로우를 효율적으로 관리",
+              },
+            ].map((feature) => (
+              <div key={feature.title} className="flex items-start gap-4">
+                <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-white/[0.07] text-zinc-300 ring-1 ring-white/10">
+                  {feature.icon}
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">{feature.title}</p>
+                  <p className="mt-0.5 text-xs leading-relaxed text-zinc-500">{feature.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <p className="text-xs text-zinc-600">© 2026 SignSafe. All rights reserved.</p>
+      </div>
+
+      {/* Right form panel */}
+      <div className="flex flex-1 flex-col items-center justify-center bg-white px-6 py-12 sm:px-10">
+        {/* Mobile logo */}
+        <div className="mb-10 flex items-center gap-2.5 lg:hidden">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-600">
+            <svg
+              className="h-5 w-5 text-white"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+            </svg>
+          </div>
+          <span className="text-lg font-bold text-zinc-900 tracking-tight">SignSafe</span>
+        </div>
+
+        <div className="w-full max-w-[400px]">{children}</div>
       </div>
     </div>
   );

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -22,6 +22,7 @@ export default function LoginPage() {
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [formState, setFormState] = useState<FormState>({
     status: "idle",
     error: null,
@@ -67,46 +68,62 @@ export default function LoginPage() {
     }
   }
 
-  const inputCls =
-    "w-full rounded-xl border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+  const inputBase =
+    "w-full rounded-xl border bg-white px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 outline-none transition-all";
+  const inputCls = `${inputBase} border-zinc-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10`;
 
   return (
-    <div className="animate-slide-in rounded-2xl bg-white px-8 py-8 shadow-sm">
-      <div className="mb-7 text-center">
-        <h2 className="text-base font-bold text-zinc-900">다시 오셨군요</h2>
-        <p className="mt-1 text-sm text-zinc-500">계정에 로그인하세요</p>
+    <div className="animate-slide-in">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight text-zinc-900">다시 오셨군요</h1>
+        <p className="mt-1.5 text-sm text-zinc-500">
+          계정에 로그인하여 계속하세요
+        </p>
       </div>
 
+      {/* Error */}
       {formState.error && (
-        <div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          <p>{formState.error}</p>
-          {formState.showResend && (
-            <div className="mt-2.5">
-              {resendState === "error" ? (
-                <p>재발송에 실패했습니다. 잠시 후 다시 시도해주세요.</p>
-              ) : (
-                <button
-                  type="button"
-                  onClick={handleResend}
-                  disabled={resendState === "sending"}
-                  className="text-xs font-semibold text-red-800 underline underline-offset-2 hover:text-red-900 disabled:opacity-50"
-                >
-                  {resendState === "sending"
-                    ? "발송 중…"
-                    : "인증 메일 재발송"}
-                </button>
-              )}
-            </div>
-          )}
+        <div className="mb-6 flex gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3.5">
+          <svg
+            className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+            />
+          </svg>
+          <div className="flex-1 text-sm text-red-700">
+            <p>{formState.error}</p>
+            {formState.showResend && (
+              <div className="mt-2">
+                {resendState === "error" ? (
+                  <p className="text-xs">재발송에 실패했습니다. 잠시 후 다시 시도해주세요.</p>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleResend}
+                    disabled={resendState === "sending"}
+                    className="text-xs font-semibold underline underline-offset-2 hover:text-red-900 disabled:opacity-50"
+                  >
+                    {resendState === "sending" ? "발송 중…" : "인증 메일 재발송"}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label
-            htmlFor="email"
-            className="mb-1.5 block text-sm font-medium text-zinc-700"
-          >
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Email */}
+        <div className="space-y-1.5">
+          <label htmlFor="email" className="block text-sm font-medium text-zinc-700">
             이메일
           </label>
           <input
@@ -121,41 +138,59 @@ export default function LoginPage() {
           />
         </div>
 
-        <div>
-          <div className="mb-1.5 flex items-center justify-between">
-            <label
-              htmlFor="password"
-              className="text-sm font-medium text-zinc-700"
-            >
+        {/* Password */}
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <label htmlFor="password" className="text-sm font-medium text-zinc-700">
               비밀번호
             </label>
             <Link
               href="/forgot-password"
-              className="text-xs font-medium text-blue-500 transition-colors hover:text-blue-700"
+              className="text-xs font-medium text-blue-600 transition-colors hover:text-blue-700"
             >
-              비밀번호를 잊으셨나요?
+              비밀번호 찾기
             </Link>
           </div>
-          <input
-            id="password"
-            type="password"
-            autoComplete="current-password"
-            required
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className={inputCls}
-            placeholder="••••••••"
-          />
+          <div className="relative">
+            <input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className={`${inputCls} pr-11`}
+              placeholder="••••••••"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3.5 top-1/2 -translate-y-1/2 text-zinc-400 transition-colors hover:text-zinc-600"
+              tabIndex={-1}
+            >
+              {showPassword ? (
+                <svg className="h-4.5 w-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+                </svg>
+              ) : (
+                <svg className="h-4.5 w-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              )}
+            </button>
+          </div>
         </div>
 
+        {/* Submit */}
         <button
           type="submit"
           disabled={formState.status === "loading"}
-          className="mt-1 w-full rounded-xl bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-2 w-full rounded-xl bg-zinc-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-zinc-700 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {formState.status === "loading" ? (
-            <span className="flex items-center justify-center gap-2">
-              <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+            <span className="flex items-center justify-center gap-2.5">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
               로그인 중…
             </span>
           ) : (
@@ -164,13 +199,14 @@ export default function LoginPage() {
         </button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-zinc-500">
+      {/* Footer */}
+      <p className="mt-8 text-center text-sm text-zinc-500">
         계정이 없으신가요?{" "}
         <Link
           href="/signup"
           className="font-semibold text-blue-600 transition-colors hover:text-blue-700"
         >
-          회원가입
+          무료로 시작하기
         </Link>
       </p>
     </div>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -10,26 +10,38 @@ type FormState = {
   error: string | null;
 };
 
+function getPasswordStrength(pw: string): { level: 0 | 1 | 2 | 3; label: string; color: string } {
+  if (pw.length === 0) return { level: 0, label: "", color: "" };
+  if (pw.length < 8) return { level: 1, label: "너무 짧음", color: "bg-red-500" };
+  const hasUpper = /[A-Z]/.test(pw);
+  const hasNumber = /\d/.test(pw);
+  const hasSpecial = /[^A-Za-z0-9]/.test(pw);
+  const extras = [hasUpper, hasNumber, hasSpecial].filter(Boolean).length;
+  if (extras >= 2) return { level: 3, label: "강함", color: "bg-green-500" };
+  if (extras >= 1) return { level: 2, label: "보통", color: "bg-amber-500" };
+  return { level: 1, label: "약함", color: "bg-red-500" };
+}
+
 export default function SignupPage() {
   const router = useRouter();
 
   const [fullName, setFullName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [agreed, setAgreed] = useState(false);
   const [formState, setFormState] = useState<FormState>({
     status: "idle",
     error: null,
   });
 
+  const strength = getPasswordStrength(password);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
 
     if (!agreed) {
-      setFormState({
-        status: "error",
-        error: "이용약관에 동의해야 합니다.",
-      });
+      setFormState({ status: "error", error: "이용약관에 동의해야 합니다." });
       return;
     }
 
@@ -47,63 +59,92 @@ export default function SignupPage() {
     }
   }
 
-  const inputCls =
-    "w-full rounded-xl border border-zinc-200 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 shadow-sm transition-colors focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10";
+  const inputBase =
+    "w-full rounded-xl border bg-white px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 outline-none transition-all";
+  const inputCls = `${inputBase} border-zinc-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10`;
 
   if (formState.status === "success") {
     return (
-      <div className="animate-slide-in rounded-2xl bg-white px-8 py-10 shadow-sm text-center space-y-4">
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+      <div className="animate-slide-in text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-green-50 ring-8 ring-green-50/50">
           <svg
-            className="h-6 w-6 text-green-600"
+            className="h-8 w-8 text-green-600"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            strokeWidth={2}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M5 13l4 4L19 7"
-            />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
           </svg>
         </div>
-        <div>
-          <h2 className="text-base font-bold text-zinc-900">받은 편지함을 확인하세요</h2>
-          <p className="mt-2 text-sm text-zinc-500">
-            <span className="font-medium text-zinc-900">{email}</span>으로
-            인증 링크를 발송했습니다. 링크를 클릭하여 계정을 활성화하세요.
-          </p>
+        <h1 className="text-2xl font-bold tracking-tight text-zinc-900">이메일을 확인하세요</h1>
+        <p className="mt-3 text-sm leading-relaxed text-zinc-500">
+          <span className="font-semibold text-zinc-800">{email}</span>으로
+          인증 링크를 보냈습니다.
+          <br />
+          링크를 클릭하여 계정을 활성화하세요.
+        </p>
+        <div className="mt-8 rounded-xl border border-zinc-100 bg-zinc-50 px-5 py-4 text-left">
+          <p className="mb-2 text-xs font-semibold text-zinc-500 uppercase tracking-wide">다음 단계</p>
+          <ol className="space-y-1.5 text-sm text-zinc-600">
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-zinc-200 text-[10px] font-bold text-zinc-600">1</span>
+              받은 편지함에서 인증 이메일 확인
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-zinc-200 text-[10px] font-bold text-zinc-600">2</span>
+              이메일의 인증 링크 클릭
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-zinc-200 text-[10px] font-bold text-zinc-600">3</span>
+              SignSafe에 로그인하여 시작
+            </li>
+          </ol>
         </div>
         <button
           onClick={() => router.push("/login")}
-          className="text-sm font-semibold text-blue-600 transition-colors hover:text-blue-700"
+          className="mt-6 w-full rounded-xl bg-zinc-900 px-4 py-3 text-sm font-semibold text-white transition-all hover:bg-zinc-700 active:scale-[0.99]"
         >
-          로그인으로 돌아가기
+          로그인 페이지로 이동
         </button>
       </div>
     );
   }
 
   return (
-    <div className="animate-slide-in rounded-2xl bg-white px-8 py-8 shadow-sm">
-      <div className="mb-7 text-center">
-        <h2 className="text-base font-bold text-zinc-900">계정 만들기</h2>
-        <p className="mt-1 text-sm text-zinc-500">무료로 시작하세요</p>
+    <div className="animate-slide-in">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight text-zinc-900">계정 만들기</h1>
+        <p className="mt-1.5 text-sm text-zinc-500">
+          무료로 시작하고 언제든 업그레이드하세요
+        </p>
       </div>
 
+      {/* Error */}
       {formState.error && (
-        <div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {formState.error}
+        <div className="mb-6 flex gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3.5">
+          <svg
+            className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+            />
+          </svg>
+          <p className="text-sm text-red-700">{formState.error}</p>
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label
-            htmlFor="fullName"
-            className="mb-1.5 block text-sm font-medium text-zinc-700"
-          >
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Full name */}
+        <div className="space-y-1.5">
+          <label htmlFor="fullName" className="block text-sm font-medium text-zinc-700">
             이름
           </label>
           <input
@@ -118,11 +159,9 @@ export default function SignupPage() {
           />
         </div>
 
-        <div>
-          <label
-            htmlFor="email"
-            className="mb-1.5 block text-sm font-medium text-zinc-700"
-          >
+        {/* Email */}
+        <div className="space-y-1.5">
+          <label htmlFor="email" className="block text-sm font-medium text-zinc-700">
             이메일
           </label>
           <input
@@ -137,54 +176,89 @@ export default function SignupPage() {
           />
         </div>
 
-        <div>
-          <label
-            htmlFor="password"
-            className="mb-1.5 block text-sm font-medium text-zinc-700"
-          >
+        {/* Password */}
+        <div className="space-y-1.5">
+          <label htmlFor="password" className="block text-sm font-medium text-zinc-700">
             비밀번호
           </label>
-          <input
-            id="password"
-            type="password"
-            autoComplete="new-password"
-            required
-            minLength={8}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className={inputCls}
-            placeholder="최소 8자 이상"
-          />
-          {password.length > 0 && password.length < 8 && (
-            <p className="mt-1.5 text-xs text-amber-600">
-              비밀번호는 최소 8자 이상이어야 합니다.
-            </p>
-          )}
-          {password.length >= 8 && (
-            <p className="mt-1.5 text-xs text-green-600">
-              비밀번호 길이가 적합합니다.
-            </p>
+          <div className="relative">
+            <input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              autoComplete="new-password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className={`${inputCls} pr-11`}
+              placeholder="최소 8자 이상"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3.5 top-1/2 -translate-y-1/2 text-zinc-400 transition-colors hover:text-zinc-600"
+              tabIndex={-1}
+            >
+              {showPassword ? (
+                <svg className="h-4.5 w-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+                </svg>
+              ) : (
+                <svg className="h-4.5 w-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              )}
+            </button>
+          </div>
+
+          {/* Password strength meter */}
+          {password.length > 0 && (
+            <div className="space-y-1.5 pt-0.5">
+              <div className="flex gap-1">
+                {[1, 2, 3].map((seg) => (
+                  <div
+                    key={seg}
+                    className={`h-1 flex-1 rounded-full transition-all duration-300 ${
+                      strength.level >= seg ? strength.color : "bg-zinc-100"
+                    }`}
+                  />
+                ))}
+              </div>
+              {strength.label && (
+                <p className={`text-xs font-medium ${
+                  strength.level === 1 ? "text-red-600" :
+                  strength.level === 2 ? "text-amber-600" :
+                  "text-green-600"
+                }`}>
+                  비밀번호 강도: {strength.label}
+                </p>
+              )}
+            </div>
           )}
         </div>
 
+        {/* Terms */}
         <label className="flex cursor-pointer items-start gap-3 pt-1">
-          <input
-            type="checkbox"
-            checked={agreed}
-            onChange={(e) => setAgreed(e.target.checked)}
-            className="mt-0.5 h-4 w-4 rounded border-zinc-300 accent-zinc-900"
-          />
-          <span className="text-sm text-zinc-600">
+          <div className="relative mt-0.5 flex-shrink-0">
+            <input
+              type="checkbox"
+              checked={agreed}
+              onChange={(e) => setAgreed(e.target.checked)}
+              className="h-4 w-4 cursor-pointer rounded border-zinc-300 accent-zinc-900"
+            />
+          </div>
+          <span className="text-sm leading-relaxed text-zinc-600">
             <a
               href="/terms"
-              className="font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              className="font-semibold text-blue-600 hover:text-blue-700 hover:underline"
             >
               이용약관
             </a>
             {" "}및{" "}
             <a
               href="/privacy"
-              className="font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              className="font-semibold text-blue-600 hover:text-blue-700 hover:underline"
             >
               개인정보처리방침
             </a>
@@ -192,14 +266,15 @@ export default function SignupPage() {
           </span>
         </label>
 
+        {/* Submit */}
         <button
           type="submit"
           disabled={formState.status === "loading"}
-          className="mt-1 w-full rounded-xl bg-zinc-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-2 w-full rounded-xl bg-zinc-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-zinc-700 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {formState.status === "loading" ? (
-            <span className="flex items-center justify-center gap-2">
-              <span className="h-3.5 w-3.5 animate-spin rounded-full border border-white/30 border-t-white" />
+            <span className="flex items-center justify-center gap-2.5">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
               계정 생성 중…
             </span>
           ) : (
@@ -208,7 +283,8 @@ export default function SignupPage() {
         </button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-zinc-500">
+      {/* Footer */}
+      <p className="mt-8 text-center text-sm text-zinc-500">
         이미 계정이 있으신가요?{" "}
         <Link
           href="/login"


### PR DESCRIPTION
## Summary

로그인·회원가입 페이지를 프리미엄 SaaS 느낌의 2-컬럼 스플릿 레이아웃으로 완전히 재설계했습니다.

**Layout (auth/layout.tsx)**
- 기존 단순 카드 중앙 정렬 → 왼쪽 브랜드 패널 + 오른쪽 폼 패널 2-컬럼 구조
- 왼쪽: `zinc-900` 다크 배경, 로고, 헤드카피, AI 분석/감사 로그/팀 협업 기능 소개
- 오른쪽: 순수 흰색 배경, 폼 중앙 정렬
- 모바일(lg 미만): 단일 컬럼, 상단 로고만 표시

**Login Page (login/page.tsx)**
- 타이틀 `text-2xl font-bold`로 크기 개선 (기존 `text-base`)
- 인풋 포커스 시 파란색 링 (`focus:ring-blue-500/10`) — 기존은 zinc 링
- 비밀번호 show/hide 토글 버튼 추가
- 에러 메시지에 경고 아이콘 추가, 레이아웃 개선

**Signup Page (signup/page.tsx)**
- 비밀번호 강도 미터: 3단계 컬러바 (빨강/주황/초록) + 텍스트 레이블 ("약함/보통/강함")
- 비밀번호 show/hide 토글 버튼 추가
- 성공 화면: "다음 단계" 번호 목록 안내 카드로 개편
- 에러 상태에 아이콘 추가

## Pre-Landing Review

No structural issues. TypeScript compiles clean with `tsc --noEmit`.

## Test plan
- [ ] `/login` — 폼 제출, 에러 표시, 비밀번호 토글, forgot-password 링크 확인
- [ ] `/signup` — 이름/이메일/비밀번호 입력, 강도 미터 동작, 체크박스, 성공 화면 확인
- [ ] 모바일(lg 미만) — 단일 컬럼 레이아웃, 로고 표시 확인
- [ ] 데스크탑(lg 이상) — 2-컬럼 레이아웃, 브랜드 패널 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)