### PR TITLE
design: 로그인/회원가입 UI 개편 + EvidencePanel 리사이즈

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { api } from "@/lib/api";
 import type { ClauseResult, EvidenceSet, RiskLevel } from "@/types";
@@ -102,6 +102,10 @@ function ConfidenceGauge({ value }: ConfidenceGaugeProps) {
 
 // ─── Main component ─────────────────────────────────────────────────────────
 
+const MIN_WIDTH = 280;
+const MAX_WIDTH = 720;
+const DEFAULT_WIDTH = 384; // sm:w-96
+
 export default function EvidencePanel({
   clauseResult,
   analysisId,
@@ -112,6 +116,26 @@ export default function EvidencePanel({
   const [evidenceSet, setEvidenceSet] = useState<EvidenceSet | null>(null);
   const [loadState, setLoadState] = useState<EvidenceLoadState>("idle");
   const [showOverride, setShowOverride] = useState(false);
+
+  const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
+  const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    dragState.current = { startX: e.clientX, startWidth: panelWidth };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  }, [panelWidth]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState.current) return;
+    const delta = dragState.current.startX - e.clientX;
+    const next = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, dragState.current.startWidth + delta));
+    setPanelWidth(next);
+  }, []);
+
+  const onPointerUp = useCallback(() => {
+    dragState.current = null;
+  }, []);
 
   const effectiveLevel: RiskLevel =
     (clauseResult.overriddenRiskLevel as RiskLevel | null) ??
@@ -150,9 +174,20 @@ export default function EvidencePanel({
         animate={{ x: 0 }}
         exit={{ x: "100%" }}
         transition={{ type: "spring", stiffness: 320, damping: 32 }}
-        className="flex w-full max-w-sm flex-shrink-0 flex-col border-l border-zinc-200 bg-white sm:w-96"
-        style={{ height: "100%" }}
+        className="relative flex flex-shrink-0 flex-col border-l border-zinc-200 bg-white"
+        style={{ width: panelWidth, height: "100%" }}
       >
+        {/* Resize handle */}
+        <div
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          className="group absolute inset-y-0 left-0 z-10 w-3 cursor-col-resize select-none"
+          title="드래그하여 너비 조절"
+        >
+          <div className="absolute inset-y-0 left-1 w-0.5 bg-transparent transition-colors group-hover:bg-blue-400 group-active:bg-blue-500" />
+        </div>
+
         {/* Header */}
         <div className="border-b border-zinc-100 px-4 py-3.5">
           <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Summary

**Auth UI 전면 개편**
- 로그인/회원가입 페이지를 2-컬럼 스플릿 레이아웃으로 재설계 — 왼쪽 브랜드 패널(zinc-900), 오른쪽 폼 패널(white)
- 모바일에서는 단일 컬럼으로 자동 전환 (브랜드 패널 숨김, 모바일 로고 표시)
- 앱 전반 디자인 시스템(rounded-xl, zinc 팔레트, blue-600 강조)과 스타일 통일
- 비밀번호 표시/숨기기 토글, 이메일 인증 재발송 UI, 에러 상태 개선

**EvidencePanel 가로 리사이즈**
- 근거 패널 왼쪽 가장자리를 드래그해 너비를 280px~720px 범위에서 자유롭게 조절
- `setPointerCapture` 적용으로 핸들 외부로 마우스 이탈 시에도 드래그 유지
- hover 시 파란 가이드 선 표시

## Pre-Landing Review
이슈 없음. `setPointerCapture` 드래그 처리, `dragState` ref 클로저 패턴, min/max clamp 모두 정상.

## Test plan
- [ ] 로그인 페이지 — 데스크톱 2-컬럼 레이아웃, 모바일 단일 컬럼 확인
- [ ] 회원가입 페이지 — 동일한 레이아웃 동작 확인
- [ ] EvidencePanel — 계약서 상세 페이지에서 조항 클릭 후 패널 좌측 가장자리 드래그하여 너비 조절 확인
- [ ] EvidencePanel — 최솟값(280px) / 최댓값(720px) 제한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)