### PR TITLE
design: 오버라이드 버튼 '수정'으로 이름 변경 및 모달 너비 확장

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -206,9 +206,9 @@ export default function EvidencePanel({
               <button
                 onClick={() => setShowOverride(true)}
                 className="cursor-pointer rounded-md px-2.5 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
-                title="리스크 수준 오버라이드"
+                title="리스크 수준 수정"
               >
-                오버라이드
+                수정
               </button>
               <button
                 onClick={onClose}

--- a/src/components/risk/OverrideDialog.tsx
+++ b/src/components/risk/OverrideDialog.tsx
@@ -83,7 +83,7 @@ export default function OverrideDialog({
 
   return (
     <Modal onClose={onClose}>
-      <div className="w-full max-w-md animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
+      <div className="w-full max-w-xl animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
         {/* Header */}
         <div className="mb-5 flex items-center justify-between">
           <h3 className="text-base font-semibold text-zinc-900">리스크 수준 오버라이드</h3>


### PR DESCRIPTION
## Summary
- EvidencePanel의 '오버라이드' 버튼 텍스트를 '수정'으로 변경
- OverrideDialog 모달 너비를 `max-w-md` → `max-w-xl`로 확장

## Test plan
- [ ] 계약서 분석 후 조항 클릭 → EvidencePanel에서 '수정' 버튼 노출 확인
- [ ] '수정' 클릭 시 모달이 더 넓게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)