### PR TITLE
fix: OverrideDialog 모달 너비 명시적 지정

### DIFF
--- a/src/components/risk/OverrideDialog.tsx
+++ b/src/components/risk/OverrideDialog.tsx
@@ -83,7 +83,7 @@ export default function OverrideDialog({
 
   return (
     <Modal onClose={onClose}>
-      <div className="w-full max-w-xl animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
+      <div className="w-[560px] max-w-[calc(100vw-2rem)] animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
         {/* Header */}
         <div className="mb-5 flex items-center justify-between">
           <h3 className="text-base font-semibold text-zinc-900">리스크 수준 오버라이드</h3>


### PR DESCRIPTION
## Summary
- `w-full max-w-xl` → `w-[560px] max-w-[calc(100vw-2rem)]`로 변경

## 원인
`Modal` 컴포넌트의 내부 wrapper div에 너비가 지정되지 않아, 자식의 `w-full`이 콘텐츠 너비 기준으로 순환 참조됨. 결과적으로 `max-w-xl`이 실제 최대폭 제한 역할을 하지 못하고 콘텐츠 너비로만 결정됨.

## 해결
`w-full` 대신 `w-[560px]`로 명시적 너비를 지정하고, 모바일 대응을 위해 `max-w-[calc(100vw-2rem)]`으로 뷰포트 초과를 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)