### PR TITLE
fix: OrgSwitcher 드롭다운 화면 이탈 문제 수정

### DIFF
--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -190,7 +190,7 @@ export function OrgSwitcher() {
         {open && (
           <div
             role="listbox"
-            className="absolute right-0 top-full mt-1.5 w-60 animate-slide-in rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
+            className="absolute left-0 bottom-full mb-1.5 w-60 animate-slide-in rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
           >
             {loadStatus === "loading" && (
               <div className="flex items-center gap-2 px-3 py-2.5">


### PR DESCRIPTION
## Summary
- `right-0 top-full` → `left-0 bottom-full`로 드롭다운 위치 변경

## 원인
| 문제 | 원인 | 수정 |
|------|------|------|
| 가로 이탈 | `right-0`으로 드롭다운 오른쪽 끝을 버튼 기준 정렬 → 좌측 화면 밖으로 벗어남 | `left-0`으로 왼쪽 끝 기준 정렬 |
| 세로 이탈 | `top-full`로 아래 방향 열기 → 사이드바 최하단 버튼이라 뷰포트 아래로 벗어남 | `bottom-full`로 위 방향 열기 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)