### PR TITLE
feat: OrgSwitcher 로고 하단 이동 및 스크롤 추가

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -145,37 +145,48 @@ function Sidebar({
     <div className="flex h-full flex-col">
       {/* Logo + collapse toggle */}
       <div className={[
-        "flex h-16 flex-shrink-0 items-center border-b border-zinc-100",
-        collapsed ? "justify-center px-3" : "justify-between px-4",
+        "flex-shrink-0 border-b border-zinc-100",
+        collapsed ? "flex h-16 items-center justify-center px-3" : "px-4",
       ].join(" ")}>
-        {!collapsed && (
-          <div className="flex items-center gap-2.5">
+        <div className={[
+          "flex h-16 items-center",
+          collapsed ? "" : "justify-between",
+        ].join(" ")}>
+          {!collapsed && (
+            <div className="flex items-center gap-2.5">
+              <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-600">
+                <svg className="h-5 w-5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                </svg>
+              </div>
+              <span className="text-base font-bold text-blue-600">SignSafe</span>
+            </div>
+          )}
+          {collapsed && (
             <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-600">
               <svg className="h-5 w-5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
               </svg>
             </div>
-            <span className="text-base font-bold text-blue-600">SignSafe</span>
+          )}
+          {onToggleCollapse && (
+            <button
+              onClick={onToggleCollapse}
+              className={[
+                "rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600",
+                collapsed ? "absolute -right-3 top-[3.75rem] z-10 border border-zinc-200 bg-white shadow-sm" : "",
+              ].join(" ")}
+              title={collapsed ? "사이드바 펼치기" : "사이드바 접기"}
+            >
+              {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+            </button>
+          )}
+        </div>
+        {/* OrgSwitcher — below logo, only when expanded */}
+        {!collapsed && (
+          <div className="pb-3">
+            <OrgSwitcher />
           </div>
-        )}
-        {collapsed && (
-          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-600">
-            <svg className="h-5 w-5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-            </svg>
-          </div>
-        )}
-        {onToggleCollapse && (
-          <button
-            onClick={onToggleCollapse}
-            className={[
-              "rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600",
-              collapsed ? "absolute -right-3 top-[3.75rem] z-10 border border-zinc-200 bg-white shadow-sm" : "",
-            ].join(" ")}
-            title={collapsed ? "사이드바 펼치기" : "사이드바 접기"}
-          >
-            {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-          </button>
         )}
       </div>
 
@@ -199,17 +210,10 @@ function Sidebar({
         "flex-shrink-0 space-y-1 border-t border-zinc-100 px-3 py-4",
         collapsed ? "items-center" : "",
       ].join(" ")}>
-        {!collapsed && (
-          <>
-            <div className="px-3 pb-1">
-              <OrgSwitcher />
-            </div>
-            {user && (
-              <div className="truncate px-3 pb-1 text-xs text-zinc-400">
-                {user.fullName}
-              </div>
-            )}
-          </>
+        {!collapsed && user && (
+          <div className="truncate px-3 pb-1 text-xs text-zinc-400">
+            {user.fullName}
+          </div>
         )}
         <NavLink href="/settings" icon={<SettingsIcon />} collapsed={collapsed} onClick={onClose}>
           설정

--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -204,36 +204,39 @@ export function OrgSwitcher() {
             {loadStatus === "idle" && orgs.length === 0 && (
               <p className="px-3 py-2.5 text-xs text-zinc-400">조직을 찾을 수 없습니다.</p>
             )}
-            {loadStatus === "idle" &&
-              orgs.map((org) => {
-                const isActive = org.id === currentOrgId;
-                return (
-                  <button
-                    key={org.id}
-                    role="option"
-                    aria-selected={isActive}
-                    onClick={() => handleSelect(org)}
-                    className="cursor-pointer flex w-full items-center justify-between px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-50"
-                  >
-                    <div className="flex items-center gap-2.5 min-w-0">
-                      <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-zinc-100 text-xs font-semibold text-zinc-600 uppercase">
-                        {org.name.charAt(0)}
+            {loadStatus === "idle" && orgs.length > 0 && (
+              <div className="max-h-[180px] overflow-y-auto">
+                {orgs.map((org) => {
+                  const isActive = org.id === currentOrgId;
+                  return (
+                    <button
+                      key={org.id}
+                      role="option"
+                      aria-selected={isActive}
+                      onClick={() => handleSelect(org)}
+                      className="cursor-pointer flex w-full items-center justify-between px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-50"
+                    >
+                      <div className="flex items-center gap-2.5 min-w-0">
+                        <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-zinc-100 text-xs font-semibold text-zinc-600 uppercase">
+                          {org.name.charAt(0)}
+                        </div>
+                        <span className="truncate">{org.name}</span>
                       </div>
-                      <span className="truncate">{org.name}</span>
-                    </div>
-                    {isActive && (
-                      <svg
-                        className="ml-2 h-3.5 w-3.5 flex-shrink-0 text-zinc-900"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
-                      </svg>
-                    )}
-                  </button>
-                );
-              })}
+                      {isActive && (
+                        <svg
+                          className="ml-2 h-3.5 w-3.5 flex-shrink-0 text-zinc-900"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
 
             <div className="mt-1 border-t border-zinc-100 pt-1">
               <Link


### PR DESCRIPTION
## Summary
- OrgSwitcher 위치: 사이드바 하단 → SignSafe 로고 바로 아래
- 드롭다운 조직 목록: `max-h-[180px] overflow-y-auto` 로 5개 기준 스크롤 처리
- 사이드바 접힘(collapsed) 상태에서는 기존과 동일하게 숨김

## Test plan
- [ ] 사이드바 로고 하단에 OrgSwitcher 버튼 노출 확인
- [ ] 조직 6개 이상 시 드롭다운 스크롤 동작 확인
- [ ] 사이드바 collapsed 상태에서 OrgSwitcher 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)