### PR TITLE
fix: OrgSwitcher 드롭다운 아래 방향으로 변경 및 오버라이드 문구 수정

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -484,7 +484,7 @@ export default function ContractViewerPage({
                     d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                   />
                 </svg>
-                <span className="hidden sm:inline">수정</span>
+                <span className="hidden sm:inline">계약서 수정</span>
               </button>
             )}
 

--- a/src/components/risk/OverrideDialog.tsx
+++ b/src/components/risk/OverrideDialog.tsx
@@ -46,7 +46,7 @@ export default function OverrideDialog({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!reason.trim()) {
-      setError("오버라이드 사유를 입력해주세요.");
+      setError("수정 사유를 입력해주세요.");
       return;
     }
     if (newLevel === currentLevel) {
@@ -75,7 +75,7 @@ export default function OverrideDialog({
 
       onApplied(updated);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "오버라이드 저장에 실패했습니다.");
+      setError(err instanceof Error ? err.message : "수정사항 저장에 실패했습니다.");
     } finally {
       setSubmitting(false);
     }
@@ -86,7 +86,7 @@ export default function OverrideDialog({
       <div className="w-[560px] max-w-[calc(100vw-2rem)] animate-slide-in rounded-2xl bg-white p-6 shadow-xl ring-1 ring-zinc-200">
         {/* Header */}
         <div className="mb-5 flex items-center justify-between">
-          <h3 className="text-base font-semibold text-zinc-900">리스크 수준 오버라이드</h3>
+          <h3 className="text-base font-semibold text-zinc-900">리스크 수준 수정</h3>
           <button
             onClick={onClose}
             className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
@@ -145,7 +145,7 @@ export default function OverrideDialog({
               rows={3}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
-              placeholder="AI 평가를 오버라이드해야 하는 이유를 설명해주세요…"
+              placeholder="AI 평가를 수정해야 하는 이유를 설명해주세요…"
               className="w-full resize-none rounded-lg border border-zinc-200 px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
             />
           </div>
@@ -175,7 +175,7 @@ export default function OverrideDialog({
                   저장 중…
                 </span>
               ) : (
-                "오버라이드 저장"
+                "수정사항 저장"
               )}
             </button>
           </div>

--- a/src/components/ui/OrgSwitcher.tsx
+++ b/src/components/ui/OrgSwitcher.tsx
@@ -190,7 +190,7 @@ export function OrgSwitcher() {
         {open && (
           <div
             role="listbox"
-            className="absolute left-0 bottom-full mb-1.5 w-60 animate-slide-in rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
+            className="absolute left-0 top-full mt-1.5 w-60 animate-slide-in rounded-xl border border-zinc-200 bg-white py-1 shadow-lg z-40"
           >
             {loadStatus === "loading" && (
               <div className="flex items-center gap-2 px-3 py-2.5">


### PR DESCRIPTION
## Summary
- OrgSwitcher 드롭다운을 위쪽(`bottom-full`)에서 아래쪽(`top-full`)으로 변경
- OverrideDialog 내 '오버라이드' 표현을 '수정'으로 일관되게 통일 (오류 메시지, 플레이스홀더, 버튼 레이블)
- 계약서 상세 페이지 수정 버튼 레이블을 '수정' → '계약서 수정'으로 명확화

## Test plan
- [ ] 사이드바에서 OrgSwitcher 버튼 클릭 시 드롭다운이 아래로 열리는지 확인
- [ ] OverrideDialog 오류 메시지 및 버튼 텍스트가 '수정' 표현으로 표시되는지 확인
- [ ] 계약서 상세 페이지 수정 버튼 레이블 '계약서 수정'으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)