### PR TITLE
fix: EvidencePanel 최대 너비 초과 시 오른쪽 텍스트 잘림 문제 수정

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -105,6 +105,7 @@ function ConfidenceGauge({ value }: ConfidenceGaugeProps) {
 const MIN_WIDTH = 280;
 const MAX_WIDTH = 720;
 const DEFAULT_WIDTH = 384; // sm:w-96
+const MIN_CENTER_WIDTH = 240;
 
 export default function EvidencePanel({
   clauseResult,
@@ -119,6 +120,7 @@ export default function EvidencePanel({
 
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
   const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
+  const panelRef = useRef<HTMLElement>(null);
 
   const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     dragState.current = { startX: e.clientX, startWidth: panelWidth };
@@ -129,8 +131,23 @@ export default function EvidencePanel({
   const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     if (!dragState.current) return;
     const delta = dragState.current.startX - e.clientX;
-    const next = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, dragState.current.startWidth + delta));
-    setPanelWidth(next);
+    const proposed = Math.max(MIN_WIDTH, dragState.current.startWidth + delta);
+
+    let effectiveMax = MAX_WIDTH;
+    const panel = panelRef.current;
+    if (panel?.parentElement) {
+      const parent = panel.parentElement;
+      const siblings = Array.from(parent.children);
+      const panelIndex = siblings.indexOf(panel);
+      // Sum widths of flex-shrink-0 siblings before the panel (e.g. left clause nav)
+      const fixedSiblingsWidth = siblings
+        .slice(0, panelIndex)
+        .filter((el) => window.getComputedStyle(el as HTMLElement).flexShrink === "0")
+        .reduce((sum, el) => sum + (el as HTMLElement).offsetWidth, 0);
+      effectiveMax = Math.max(MIN_WIDTH, parent.offsetWidth - fixedSiblingsWidth - MIN_CENTER_WIDTH);
+    }
+
+    setPanelWidth(Math.min(proposed, effectiveMax));
   }, []);
 
   const onPointerUp = useCallback(() => {
@@ -174,6 +191,7 @@ export default function EvidencePanel({
         animate={{ x: 0 }}
         exit={{ x: "100%" }}
         transition={{ type: "spring", stiffness: 320, damping: 32 }}
+        ref={panelRef}
         className="relative flex flex-shrink-0 flex-col border-l border-zinc-200 bg-white"
         style={{ width: panelWidth, height: "100%" }}
       >


### PR DESCRIPTION
## Summary
- 드래그로 EvidencePanel을 최대로 늘렸을 때 부모 컨테이너를 넘어 오른쪽 내용이 잘리는 문제 수정
- `onPointerMove` 핸들러에서 부모 컨테이너 너비를 실시간으로 읽고, flex-shrink-0 형제 요소(좌측 조항 내비게이션) 너비 + 중앙 영역 최소 너비(240px)를 제외한 값을 동적 최대값으로 사용
- `panelRef`를 `motion.aside`에 연결해 DOM 측정에 활용

## Root cause
`MAX_WIDTH = 720` 고정값이 화면 크기와 무관하게 적용되어, 좌측 조항 내비게이션(288px) + 패널(720px)의 합이 컨테이너 너비를 초과할 때 `overflow-hidden`에 의해 패널 우측이 잘렸음.

## Test plan
- [ ] 1280px 이하 화면에서 EvidencePanel을 최대로 드래그했을 때 우측 텍스트가 잘리지 않는지 확인
- [ ] 패널이 중앙 뷰어 영역을 최소 240px 이상 남기며 멈추는지 확인
- [ ] 넓은 화면(1440px+)에서 기존대로 720px까지 늘어나는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)