### PR TITLE
fix: EvidencePanel 리사이즈 clamp — 컨테이너 초과 및 horizontal scroll 방지

### DIFF
--- a/src/app/(app)/contracts/[id]/page.tsx
+++ b/src/app/(app)/contracts/[id]/page.tsx
@@ -353,7 +353,7 @@ export default function ContractViewerPage({
   }
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden">
+    <div className="flex h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden overflow-x-hidden">
       {/* Left: Clause navigation — desktop only */}
       <aside className="hidden w-64 flex-shrink-0 overflow-y-auto border-r border-zinc-200 bg-white md:block lg:w-72">
         {loadState === "loading" ? (

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -105,6 +105,7 @@ function ConfidenceGauge({ value }: ConfidenceGaugeProps) {
 const MIN_WIDTH = 280;
 const MAX_WIDTH = 720;
 const DEFAULT_WIDTH = 384; // sm:w-96
+const MIN_CENTER_WIDTH = 280;
 
 export default function EvidencePanel({
   clauseResult,
@@ -118,24 +119,64 @@ export default function EvidencePanel({
   const [showOverride, setShowOverride] = useState(false);
 
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
-  const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
+  const panelRef = useRef<HTMLElement>(null);
+  const dragState = useRef<{
+    startX: number;
+    startWidth: number;
+    maxWidth: number;
+  } | null>(null);
+  const rafRef = useRef<number | null>(null);
 
-  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    dragState.current = { startX: e.clientX, startWidth: panelWidth };
-    e.currentTarget.setPointerCapture(e.pointerId);
-    e.preventDefault();
-  }, [panelWidth]);
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // 드래그 시작 시점에 컨테이너 크기를 한 번만 측정해 maxWidth 확정
+      let maxWidth = MAX_WIDTH;
+      const panel = panelRef.current;
+      if (panel?.parentElement) {
+        const container = panel.parentElement;
+        const containerWidth = container.offsetWidth;
+        // 패널보다 앞에 있는 flex-shrink-0 형제(좌측 조항 내비게이션) 너비 합산
+        let leftFixedWidth = 0;
+        for (const child of Array.from(container.children)) {
+          if (child === panel) break;
+          if (window.getComputedStyle(child as HTMLElement).flexShrink === "0") {
+            leftFixedWidth += (child as HTMLElement).offsetWidth;
+          }
+        }
+        maxWidth = Math.min(
+          MAX_WIDTH,
+          Math.max(MIN_WIDTH, containerWidth - leftFixedWidth - MIN_CENTER_WIDTH),
+        );
+      }
+      dragState.current = { startX: e.clientX, startWidth: panelWidth, maxWidth };
+      e.currentTarget.setPointerCapture(e.pointerId);
+      e.preventDefault();
+    },
+    [panelWidth],
+  );
 
   const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     if (!dragState.current) return;
-    const delta = dragState.current.startX - e.clientX;
-    const proposed = Math.max(MIN_WIDTH, dragState.current.startWidth + delta);
-    // Viewport의 50%를 상한으로 — 좌측 패널들이 항상 공간을 확보하도록 보장
-    const effectiveMax = Math.min(MAX_WIDTH, Math.floor(window.innerWidth * 0.5));
-    setPanelWidth(Math.min(proposed, effectiveMax));
+    // 이미 rAF가 예약돼 있으면 스킵 — 화면 주사율로 자동 스로틀링
+    if (rafRef.current !== null) return;
+    const clientX = e.clientX;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      if (!dragState.current) return;
+      const delta = dragState.current.startX - clientX;
+      const next = Math.min(
+        dragState.current.maxWidth,
+        Math.max(MIN_WIDTH, dragState.current.startWidth + delta),
+      );
+      setPanelWidth(next);
+    });
   }, []);
 
   const onPointerUp = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
     dragState.current = null;
   }, []);
 
@@ -171,6 +212,7 @@ export default function EvidencePanel({
   return (
     <AnimatePresence>
       <motion.aside
+        ref={panelRef}
         key="evidence-panel"
         initial={{ x: "100%" }}
         animate={{ x: 0 }}


### PR DESCRIPTION
## Summary
- `onPointerDown` 시점에 실제 DOM(`container.offsetWidth`, 좌측 `flex-shrink-0` 형제 너비)을 측정해 드래그 가능한 `maxWidth`를 확정
- `onPointerMove`는 저장된 `maxWidth`로만 clamp → 매 이벤트마다 DOM 재접근 없음
- `requestAnimationFrame`으로 mousemove 스로틀링 (화면 주사율 기준, 최대 60fps)
- `motion.aside`에 `ref` 연결 + `overflow-hidden` 유지
- 계약서 flex 컨테이너에 `overflow-x-hidden` 명시 추가

## Root cause (이전 수정의 한계)
`window.innerWidth * 0.5`는 앱 사이드바(256px)를 포함한 값이어서, 실제 flex 컨테이너 너비보다 큰 값이 상한으로 잡혀 여전히 overflow 발생 가능.

## Test plan
- [ ] 좌측 조항 내비게이션 + 중앙 뷰어가 열린 상태에서 EvidencePanel 드래그 시 horizontal scroll 미발생 확인
- [ ] 다양한 화면 크기(1024/1280/1440px)에서 패널이 중앙 영역 최소 280px를 남기고 멈추는지 확인
- [ ] 드래그 성능(60fps 유지) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)