### PR TITLE
fix: EvidencePanel MAX_WIDTH 720 → 680

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -103,7 +103,7 @@ function ConfidenceGauge({ value }: ConfidenceGaugeProps) {
 // ─── Main component ─────────────────────────────────────────────────────────
 
 const MIN_WIDTH = 280;
-const MAX_WIDTH = 720;
+const MAX_WIDTH = 680;
 const DEFAULT_WIDTH = 384; // sm:w-96
 const MIN_CENTER_WIDTH = 280;
 


### PR DESCRIPTION
EvidencePanel 최대 너비를 720px에서 680px으로 조정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)