### PR TITLE
fix: EvidencePanel rAF 타이밍 — latestPointerX ref로 stale 좌표 방지

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -126,6 +126,8 @@ export default function EvidencePanel({
     maxWidth: number;
   } | null>(null);
   const rafRef = useRef<number | null>(null);
+  // rAF 콜백이 항상 최신 포인터 위치를 읽도록 별도 ref에 저장
+  const latestPointerX = useRef<number | null>(null);
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
@@ -135,7 +137,6 @@ export default function EvidencePanel({
       if (panel?.parentElement) {
         const container = panel.parentElement;
         const containerWidth = container.offsetWidth;
-        // 패널보다 앞에 있는 flex-shrink-0 형제(좌측 조항 내비게이션) 너비 합산
         let leftFixedWidth = 0;
         for (const child of Array.from(container.children)) {
           if (child === panel) break;
@@ -149,6 +150,7 @@ export default function EvidencePanel({
         );
       }
       dragState.current = { startX: e.clientX, startWidth: panelWidth, maxWidth };
+      latestPointerX.current = e.clientX;
       e.currentTarget.setPointerCapture(e.pointerId);
       e.preventDefault();
     },
@@ -157,13 +159,13 @@ export default function EvidencePanel({
 
   const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     if (!dragState.current) return;
-    // 이미 rAF가 예약돼 있으면 스킵 — 화면 주사율로 자동 스로틀링
+    // 최신 좌표를 항상 갱신 — rAF가 실행될 때 stale한 값 사용 방지
+    latestPointerX.current = e.clientX;
     if (rafRef.current !== null) return;
-    const clientX = e.clientX;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
-      if (!dragState.current) return;
-      const delta = dragState.current.startX - clientX;
+      if (!dragState.current || latestPointerX.current === null) return;
+      const delta = dragState.current.startX - latestPointerX.current;
       const next = Math.min(
         dragState.current.maxWidth,
         Math.max(MIN_WIDTH, dragState.current.startWidth + delta),
@@ -172,12 +174,13 @@ export default function EvidencePanel({
     });
   }, []);
 
-  const onPointerUp = useCallback(() => {
+  const stopDrag = useCallback(() => {
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
     }
     dragState.current = null;
+    latestPointerX.current = null;
   }, []);
 
   const effectiveLevel: RiskLevel =
@@ -225,7 +228,8 @@ export default function EvidencePanel({
         <div
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
+          onPointerUp={stopDrag}
+          onPointerCancel={stopDrag}
           className="group absolute inset-y-0 left-0 z-10 w-3 cursor-col-resize select-none"
           title="드래그하여 너비 조절"
         >


### PR DESCRIPTION
## 문제
`clientX`를 이벤트 핸들러의 클로저에 캡처한 뒤 rAF 콜백에서 사용했기 때문에, rAF와 `pointerup`이 같은 프레임에 겹칠 때 캡처된 stale한 좌표로 rAF가 실행되어 width가 순간 초과될 수 있었음.

## 수정
- `latestPointerX` ref에 항상 최신 포인터 위치를 저장
- rAF 콜백은 클로저의 `clientX` 대신 `latestPointerX.current`를 읽음
- `onPointerUp` / `onPointerCancel`을 `stopDrag`로 통합 → 드래그 상태 + rAF + latestPointerX 세 가지 모두 확실히 정리
- `pointercancel` 핸들러 추가 (터치/펜 입력 강제 종료 시 대응)

## Test plan
- [ ] 빠르게 드래그 후 즉시 릴리즈 시 패널이 maxWidth를 초과하지 않는지 확인
- [ ] 드래그 중 Alt+Tab 등으로 포커스 이탈 시 드래그가 정상 종료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)