### PR TITLE
feat: 조항 목록에 content 미리보기 추가

### DIFF
--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -262,7 +262,7 @@ export default function ClauseNav({
 
                     <div className="flex-1 min-w-0">
                       <div className="flex items-start justify-between gap-2">
-                        <span className="flex-1 leading-snug line-clamp-2 text-xs font-medium">
+                        <span className="flex-1 leading-snug line-clamp-1 text-xs font-medium">
                           {clause.label ?? `Clause ${clause.clauseIndex + 1}`}
                         </span>
                         <div className="flex flex-shrink-0 items-center gap-1">
@@ -281,6 +281,15 @@ export default function ClauseNav({
                           )}
                         </div>
                       </div>
+                      {clause.content && (
+                        <p
+                          className={`mt-0.5 line-clamp-2 text-xs leading-relaxed ${
+                            isSelected ? "text-zinc-300" : "text-zinc-400"
+                          }`}
+                        >
+                          {clause.content}
+                        </p>
+                      )}
                       {clause.pageStart > 0 && (
                         <span
                           className={`mt-0.5 block text-xs ${


### PR DESCRIPTION
## Summary
- `clause.label`(조항 번호/제목)은 헤더로 유지 (`line-clamp-1`)
- 그 아래에 `clause.content`를 `line-clamp-2`로 잘라 미리보기로 표시
- 선택된 조항은 미리보기 텍스트도 `text-zinc-300`으로 색상 대응

## 개선 효과
조항 목록만 훑어봐도 각 조항의 내용을 파악할 수 있어, 원하는 조항을 찾기 위해 하나씩 클릭할 필요가 없어짐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)