### PR TITLE
design: ClauseNav 선택 항목 색상 수정

### DIFF
--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -246,7 +246,7 @@ export default function ClauseNav({
                   className={[
                     "cursor-pointer group w-full rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
                     isSelected
-                      ? "bg-zinc-900 text-white"
+                      ? "bg-zinc-500 text-black"
                       : "text-zinc-700 hover:bg-zinc-100",
                   ].join(" ")}
                 >


### PR DESCRIPTION
선택된 조항 배경색 `bg-zinc-900` → `bg-zinc-500`, 텍스트 `text-white` → `text-black` 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)