### PR TITLE
design: ClauseNav 선택 항목 색상 blue 계열로 변경

### DIFF
--- a/src/components/viewer/ClauseNav.tsx
+++ b/src/components/viewer/ClauseNav.tsx
@@ -246,7 +246,7 @@ export default function ClauseNav({
                   className={[
                     "cursor-pointer group w-full rounded-lg px-3 py-2.5 text-left text-sm transition-colors",
                     isSelected
-                      ? "bg-zinc-500 text-black"
+                      ? "bg-blue-50 text-blue-700"
                       : "text-zinc-700 hover:bg-zinc-100",
                   ].join(" ")}
                 >
@@ -284,7 +284,7 @@ export default function ClauseNav({
                       {clause.content && (
                         <p
                           className={`mt-0.5 line-clamp-2 text-xs leading-relaxed ${
-                            isSelected ? "text-zinc-300" : "text-zinc-400"
+                            isSelected ? "text-blue-500" : "text-zinc-400"
                           }`}
                         >
                           {clause.content}
@@ -293,7 +293,7 @@ export default function ClauseNav({
                       {clause.pageStart > 0 && (
                         <span
                           className={`mt-0.5 block text-xs ${
-                            isSelected ? "text-zinc-300" : "text-zinc-400"
+                            isSelected ? "text-blue-400" : "text-zinc-400"
                           }`}
                         >
                           p.&nbsp;{clause.pageStart}


### PR DESCRIPTION
선택된 조항 색상을 앱의 NavLink 활성 상태와 동일한 blue 계열로 통일.

- 배경/텍스트: `bg-zinc-500 text-black` → `bg-blue-50 text-blue-700`
- 미리보기: `text-zinc-300` → `text-blue-500`
- 페이지 번호: `text-zinc-300` → `text-blue-400`

🤖 Generated with [Claude Code](https://claude.com/claude-code)